### PR TITLE
Delete .gitreview

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -1,5 +1,0 @@
-[gerrit]
-host=dmdirc.com
-port=29418
-project=parser
-defaultbranch=master


### PR DESCRIPTION
We've ditched gerrit for DMDIrc, so this is now rather pointless.
