### PR TITLE
Remove signing configuration.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ subprojects {
 
     apply plugin: 'maven-publish'
     apply plugin: 'java'
-    apply plugin: 'signing'
 
     sourceSets {
         main {
@@ -86,10 +85,6 @@ subprojects {
                 url 'http://nexus.dmdirc.com/nexus/content/repositories/snapshots/'
             }
         }
-    }
-
-    signing {
-        sign configurations.archives
     }
 
     sourceCompatibility = 1.7


### PR DESCRIPTION
This breaks CI, and the way the plugin works means you need your
password stored in a config file, which I ain't doing.

Will manually sign releases for now, I guess.
