### PR TITLE
Tidy up gradle source sets.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,16 +7,8 @@ subprojects {
     apply plugin: 'java'
 
     sourceSets {
-        main {
-            java {
-                srcDir 'src'
-            }
-        }
-        test {
-            java {
-                srcDir 'test'
-            }
-        }
+        main.java.srcDirs = ['src']
+        test.java.srcDirs = ['test']
     }
 
     publishing {


### PR DESCRIPTION
This replaces the default source directories (src/main/java, etc)
with our own, instead of just appending ours to the list.
