### PR TITLE
Remove all usages of getCallbackType.

### DIFF
--- a/common/src/com/dmdirc/parser/common/CallbackManager.java
+++ b/common/src/com/dmdirc/parser/common/CallbackManager.java
@@ -200,7 +200,7 @@ public class CallbackManager {
      * @param callback Name of type of callback object.
      * @return CallbackObject returns the callback object for this type
      */
-    public CallbackObject getCallbackType(final Class<? extends CallbackInterface> callback) {
+    private CallbackObject getCallbackType(final Class<? extends CallbackInterface> callback) {
         if (!callbackHash.containsKey(callback)) {
             throw new CallbackNotFoundException("Callback not found: " + callback.getName()
                     + "\n\nMy class: " + getClass().getName()

--- a/common/src/com/dmdirc/parser/common/CallbackObject.java
+++ b/common/src/com/dmdirc/parser/common/CallbackObject.java
@@ -101,10 +101,9 @@ public class CallbackObject {
      * Call the OnErrorInfo callback.
      *
      * @param errorInfo ParserError object to pass as error.
-     * @return true if error call succeeded, false otherwise
      */
-    protected final boolean callErrorInfo(final ParserError errorInfo) {
-        return myManager.getCallbackType(ErrorInfoListener.class).call(errorInfo);
+    protected final void callErrorInfo(final ParserError errorInfo) {
+        myManager.getCallback(ErrorInfoListener.class).onErrorInfo(null, null, errorInfo);
     }
 
     /**

--- a/common/src/com/dmdirc/parser/common/MyInfo.java
+++ b/common/src/com/dmdirc/parser/common/MyInfo.java
@@ -31,20 +31,8 @@ import com.dmdirc.parser.interfaces.Parser;
  */
 public class MyInfo {
 
-    /** Character to prepend to nickname if in use (Default "_"). */
-    private char prependChar = '_';
-
     /** Nickname to attempt to use on IRC. */
     private String nickname;
-
-    /**
-     * Alternative nickname to attempt to use on IRC. If the first nickname is
-     * in use, and a NickInUse message is recieved before 001, we will attempt
-     * to use this nickname instead.<br>
-     * If this also fails, we will start prepending the prependChar character
-     * (_) to the main nickname
-     */
-    private String altNickname;
 
     /** Realname string to use. */
     private String realname;
@@ -66,12 +54,10 @@ public class MyInfo {
             nickname = "IRCParser";
             username = "IRCParser";
             realname = "DMDIrc IRCParser";
-            altNickname = "IRC-Parser";
         } else {
             nickname = result;
             username = nickname;
             realname = nickname + " - DMDIrc";
-            altNickname = nickname + '-';
         }
     }
 
@@ -93,26 +79,6 @@ public class MyInfo {
      */
     public String getNickname() {
         return nickname;
-    }
-
-    /**
-     * Set the Alternative Nickname.
-     *
-     * @param newValue Value to set to.
-     */
-    public void setAltNickname(final String newValue) {
-        if (newValue != null && !newValue.isEmpty()) {
-            altNickname = newValue;
-        }
-    }
-
-    /**
-     * Get the Alternative Nickname.
-     *
-     * @return Current Nickname
-     */
-    public String getAltNickname() {
-        return altNickname;
     }
 
     /**
@@ -153,24 +119,6 @@ public class MyInfo {
      */
     public String getUsername() {
         return username;
-    }
-
-    /**
-     * Set the Prepend Character.
-     *
-     * @param newValue Value to set to.
-     */
-    public void setPrependChar(final char newValue) {
-        prependChar = newValue;
-    }
-
-    /**
-     * Get the Prepend Character.
-     *
-     * @return Current Prepend Character
-     */
-    public char getPrependChar() {
-        return prependChar;
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/IRCParser.java
+++ b/irc/src/com/dmdirc/parser/irc/IRCParser.java
@@ -617,10 +617,9 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
      * Callback to all objects implementing the PingFailed Callback.
      *
      * @see PingFailureListener
-     * @return True if any callback was called, false otherwise.
      */
-    protected boolean callPingFailed() {
-        return getCallbackManager().getCallbackType(PingFailureListener.class).call();
+    protected void callPingFailed() {
+        getCallbackManager().getCallback(PingFailureListener.class).onPingFailed(null, null);
     }
 
     /**
@@ -1920,17 +1919,9 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
 
             return;
         }
+
         if (getPingNeeded()) {
-            if (!callPingFailed()) {
-                pingTimerSem.acquireUninterruptibly();
-
-                if (pingTimer != null && pingTimer.equals(timer)) {
-                    pingTimer.cancel();
-                }
-                pingTimerSem.release();
-
-                disconnect("Server not responding.");
-            }
+            callPingFailed();
         } else {
             --pingCountDown;
             if (pingCountDown < 1) {

--- a/irc/src/com/dmdirc/parser/irc/ProcessingManager.java
+++ b/irc/src/com/dmdirc/parser/irc/ProcessingManager.java
@@ -267,12 +267,12 @@ public class ProcessingManager {
     /**
      * Callback to all objects implementing the onNumeric Callback.
      *
-     * @see com.dmdirc.parser.interfaces.callbacks.NumericListener
+     * @see NumericListener
      * @param numeric What numeric is this for
      * @param token IRC Tokenised line
-     * @return true if a method was called, false otherwise
      */
-    protected boolean callNumeric(final int numeric, final String... token) {
-        return parser.getCallbackManager().getCallbackType(NumericListener.class).call(numeric, token);
+    protected void callNumeric(final int numeric, final String... token) {
+        parser.getCallbackManager().getCallback(NumericListener.class)
+                .onNumeric(null, null, numeric, token);
     }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/Process004005.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/Process004005.java
@@ -94,8 +94,8 @@ public class Process004005 extends IRCProcessor {
         final String ircdVersion = parser.getServerSoftware();
         final String ircdType = parser.getServerSoftwareType();
 
-        getCallbackManager().getCallbackType(NetworkDetectedListener.class)
-                .call(networkName, ircdVersion, ircdType);
+        getCallbackManager().getCallback(NetworkDetectedListener.class)
+                .onGotNetwork(null, null, networkName, ircdVersion, ircdType);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/Process464.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/Process464.java
@@ -68,6 +68,7 @@ public class Process464 extends IRCProcessor {
      * @see PasswordRequiredListener
      */
     protected void callPasswordRequired() {
-        getCallbackManager().getCallbackType(PasswordRequiredListener.class).call();
+        getCallbackManager().getCallback(PasswordRequiredListener.class)
+                .onPasswordRequired(null, null);
     }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessAway.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessAway.java
@@ -90,7 +90,8 @@ public class ProcessAway extends IRCProcessor {
      */
     protected void callAwayState(final AwayState oldState, final AwayState currentState,
             final String reason) {
-        getCallbackManager().getCallbackType(AwayStateListener.class).call(oldState, currentState, reason);
+        getCallbackManager().getCallback(AwayStateListener.class)
+                .onAwayState(null, null, oldState, currentState, reason);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessInvite.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessInvite.java
@@ -63,7 +63,8 @@ public class ProcessInvite extends IRCProcessor {
      * @param channel The name of the channel we were invited to
      */
     protected void callInvite(final String userHost, final String channel) {
-        getCallbackManager().getCallbackType(InviteListener.class).call(userHost, channel);
+        getCallbackManager().getCallback(InviteListener.class)
+                .onInvite(null, null, userHost, channel);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessJoin.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessJoin.java
@@ -182,7 +182,8 @@ public class ProcessJoin extends IRCProcessor {
      */
     protected void callChannelJoin(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient) {
-        getCallbackManager().getCallbackType(ChannelJoinListener.class).call(cChannel, cChannelClient);
+        getCallbackManager().getCallback(ChannelJoinListener.class)
+                .onChannelJoin(null, null, cChannel, cChannelClient);
     }
 
     /**
@@ -192,7 +193,8 @@ public class ProcessJoin extends IRCProcessor {
      * @param cChannel Channel Object
      */
     protected void callChannelSelfJoin(final ChannelInfo cChannel) {
-        getCallbackManager().getCallbackType(ChannelSelfJoinListener.class).call(cChannel);
+        getCallbackManager().getCallback(ChannelSelfJoinListener.class)
+                .onChannelSelfJoin(null, null, cChannel);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessKick.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessKick.java
@@ -120,7 +120,9 @@ public class ProcessKick extends IRCProcessor {
     protected void callChannelKick(final ChannelInfo cChannel,
             final ChannelClientInfo cKickedClient, final ChannelClientInfo cKickedByClient,
             final String sReason, final String sKickedByHost) {
-        getCallbackManager().getCallbackType(ChannelKickListener.class).call(cChannel, cKickedClient, cKickedByClient, sReason, sKickedByHost);
+        getCallbackManager().getCallback(ChannelKickListener.class)
+                .onChannelKick(null, null, cChannel, cKickedClient, cKickedByClient, sReason,
+                        sKickedByHost);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessListModes.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessListModes.java
@@ -294,6 +294,7 @@ public class ProcessListModes extends IRCProcessor {
      * @param mode the mode that we got list modes for.
      */
     protected void callChannelGotListModes(final ChannelInfo cChannel, final char mode) {
-        getCallbackManager().getCallbackType(ChannelListModeListener.class).call(cChannel, mode);
+        getCallbackManager().getCallback(ChannelListModeListener.class)
+                .onChannelGotListModes(null, null, cChannel, mode);
     }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessMOTD.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessMOTD.java
@@ -72,7 +72,8 @@ public class ProcessMOTD extends IRCProcessor {
      * @see MotdEndListener
      */
     protected void callMOTDEnd(final boolean noMOTD, final String data) {
-        getCallbackManager().getCallbackType(MotdEndListener.class).call(noMOTD, data);
+        getCallbackManager().getCallback(MotdEndListener.class)
+                .onMOTDEnd(null, null, noMOTD, data);
     }
 
     /**
@@ -82,7 +83,8 @@ public class ProcessMOTD extends IRCProcessor {
      * @param data Incomming Line.
      */
     protected void callMOTDLine(final String data) {
-        getCallbackManager().getCallbackType(MotdLineListener.class).call(data);
+        getCallbackManager().getCallback(MotdLineListener.class)
+                .onMOTDLine(null, null, data);
     }
 
     /**
@@ -92,7 +94,8 @@ public class ProcessMOTD extends IRCProcessor {
      * @param data Incomming Line.
      */
     protected void callMOTDStart(final String data) {
-        getCallbackManager().getCallbackType(MotdStartListener.class).call(data);
+        getCallbackManager().getCallback(MotdStartListener.class)
+                .onMOTDStart(null, null, data);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessMessage.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessMessage.java
@@ -302,7 +302,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callChannelAction(final Date date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sMessage, final String sHost) {
-        getCallbackManager().getCallbackType(ChannelActionListener.class).call(date, cChannel, cChannelClient, sMessage, sHost);
+        getCallbackManager().getCallback(ChannelActionListener.class)
+                .onChannelAction(null, date, cChannel, cChannelClient, sMessage, sHost);
     }
 
     /**
@@ -319,7 +320,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
     protected void callChannelCTCP(final Date date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sType, final String sMessage,
             final String sHost) {
-        getCallbackManager().getCallbackType(ChannelCtcpListener.class).call(date, cChannel, cChannelClient, sType, sMessage, sHost);
+        getCallbackManager().getCallback(ChannelCtcpListener.class)
+                .onChannelCTCP(null, date, cChannel, cChannelClient, sType, sMessage, sHost);
     }
 
     /**
@@ -336,7 +338,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
     protected void callChannelCTCPReply(final Date date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sType, final String sMessage,
             final String sHost) {
-        getCallbackManager().getCallbackType(ChannelCtcpReplyListener.class).call(date, cChannel, cChannelClient, sType, sMessage, sHost);
+        getCallbackManager().getCallback(ChannelCtcpReplyListener.class)
+                .onChannelCTCPReply(null, date, cChannel, cChannelClient, sType, sMessage, sHost);
     }
 
     /**
@@ -351,7 +354,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callChannelMessage(final Date date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sMessage, final String sHost) {
-        getCallbackManager().getCallbackType(ChannelMessageListener.class).call(date, cChannel, cChannelClient, sMessage, sHost);
+        getCallbackManager().getCallback(ChannelMessageListener.class)
+                .onChannelMessage(null, date, cChannel, cChannelClient, sMessage, sHost);
     }
 
     /**
@@ -366,7 +370,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callChannelNotice(final Date date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sMessage, final String sHost) {
-        getCallbackManager().getCallbackType(ChannelNoticeListener.class).call(date, cChannel, cChannelClient, sMessage, sHost);
+        getCallbackManager().getCallback(ChannelNoticeListener.class)
+                .onChannelNotice(null, date, cChannel, cChannelClient, sMessage, sHost);
     }
 
     /**
@@ -383,7 +388,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
     protected void callChannelModeNotice(final Date date, final char prefix,
             final ChannelInfo cChannel, final ChannelClientInfo cChannelClient,
             final String sMessage, final String sHost) {
-        getCallbackManager().getCallbackType(ChannelModeNoticeListener.class).call(date, cChannel, prefix, cChannelClient, sMessage, sHost);
+        getCallbackManager().getCallback(ChannelModeNoticeListener.class)
+                .onChannelModeNotice(null, date, cChannel, prefix, cChannelClient, sMessage, sHost);
     }
 
     /**
@@ -400,7 +406,9 @@ public class ProcessMessage extends TimestampedIRCProcessor {
     protected void callChannelModeMessage(final Date date, final char prefix,
             final ChannelInfo cChannel, final ChannelClientInfo cChannelClient,
             final String sMessage, final String sHost) {
-        getCallbackManager().getCallbackType(ChannelModeMessageListener.class).call(date, cChannel, prefix, cChannelClient, sMessage, sHost);
+        getCallbackManager().getCallback(ChannelModeMessageListener.class)
+                .onChannelModeMessage(null, date, cChannel, prefix, cChannelClient, sMessage,
+                        sHost);
     }
 
     /**
@@ -412,7 +420,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sHost Hostname of sender (or servername)
      */
     protected void callPrivateAction(final Date date, final String sMessage, final String sHost) {
-        getCallbackManager().getCallbackType(PrivateActionListener.class).call(date, sMessage, sHost);
+        getCallbackManager().getCallback(PrivateActionListener.class)
+                .onPrivateAction(null, date, sMessage, sHost);
     }
 
     /**
@@ -426,7 +435,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callPrivateCTCP(final Date date, final String sType, final String sMessage,
             final String sHost) {
-        getCallbackManager().getCallbackType(PrivateCtcpListener.class).call(date, sType, sMessage, sHost);
+        getCallbackManager().getCallback(PrivateCtcpListener.class)
+                .onPrivateCTCP(null, date, sType, sMessage, sHost);
     }
 
     /**
@@ -440,7 +450,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callPrivateCTCPReply(final Date date, final String sType, final String sMessage,
             final String sHost) {
-        getCallbackManager().getCallbackType(PrivateCtcpReplyListener.class).call(date, sType, sMessage, sHost);
+        getCallbackManager().getCallback(PrivateCtcpReplyListener.class)
+                .onPrivateCTCPReply(null, date, sType, sMessage, sHost);
     }
 
     /**
@@ -452,7 +463,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sHost Hostname of sender (or servername)
      */
     protected void callPrivateMessage(final Date date, final String sMessage, final String sHost) {
-        getCallbackManager().getCallbackType(PrivateMessageListener.class).call(date, sMessage, sHost);
+        getCallbackManager().getCallback(PrivateMessageListener.class)
+                .onPrivateMessage(null, date, sMessage, sHost);
     }
 
     /**
@@ -464,7 +476,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sHost Hostname of sender (or servername)
      */
     protected void callPrivateNotice(final Date date, final String sMessage, final String sHost) {
-        getCallbackManager().getCallbackType(PrivateNoticeListener.class).call(date, sMessage, sHost);
+        getCallbackManager().getCallback(PrivateNoticeListener.class)
+                .onPrivateNotice(null, date, sMessage, sHost);
     }
 
     /**
@@ -476,7 +489,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sHost Hostname of sender (or servername)
      */
     protected void callServerNotice(final Date date, final String sMessage, final String sHost) {
-        getCallbackManager().getCallbackType(ServerNoticeListener.class).call(date, sMessage, sHost);
+        getCallbackManager().getCallback(ServerNoticeListener.class)
+                .onServerNotice(null, date, sMessage, sHost);
     }
 
     /**
@@ -490,7 +504,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownAction(final Date date, final String sMessage, final String sTarget,
             final String sHost) {
-        getCallbackManager().getCallbackType(UnknownActionListener.class).call(date, sMessage, sTarget, sHost);
+        getCallbackManager().getCallback(UnknownActionListener.class)
+                .onUnknownAction(null, date, sMessage, sTarget, sHost);
     }
 
     /**
@@ -505,7 +520,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownCTCP(final Date date, final String sType, final String sMessage,
             final String sTarget, final String sHost) {
-        getCallbackManager().getCallbackType(UnknownCtcpListener.class).call(date, sType, sMessage, sTarget, sHost);
+        getCallbackManager().getCallback(UnknownCtcpListener.class)
+                .onUnknownCTCP(null, date, sType, sMessage, sTarget, sHost);
     }
 
     /**
@@ -520,7 +536,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownCTCPReply(final Date date, final String sType, final String sMessage,
             final String sTarget, final String sHost) {
-        getCallbackManager().getCallbackType(UnknownCtcpReplyListener.class).call(date, sType, sMessage, sTarget, sHost);
+        getCallbackManager().getCallback(UnknownCtcpReplyListener.class)
+                .onUnknownCTCPReply(null, date, sType, sMessage, sTarget, sHost);
     }
 
     /**
@@ -534,7 +551,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownMessage(final Date date, final String sMessage, final String sTarget,
             final String sHost) {
-        getCallbackManager().getCallbackType(UnknownMessageListener.class).call(date, sMessage, sTarget, sHost);
+        getCallbackManager().getCallback(UnknownMessageListener.class)
+                .onUnknownMessage(null, date, sMessage, sTarget, sHost);
     }
 
     /**
@@ -548,7 +566,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownNotice(final Date date, final String sMessage, final String sTarget,
             final String sHost) {
-        getCallbackManager().getCallbackType(UnknownNoticeListener.class).call(date, sMessage, sTarget, sHost);
+        getCallbackManager().getCallback(UnknownNoticeListener.class)
+                .onUnknownNotice(null, date, sMessage, sTarget, sHost);
     }
 
     /**
@@ -562,7 +581,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownServerNotice(final Date date, final String sMessage,
             final String sTarget, final String sHost) {
-        getCallbackManager().getCallbackType(UnknownServerNoticeListener.class).call(date, sMessage, sTarget, sHost);
+        getCallbackManager().getCallback(UnknownServerNoticeListener.class)
+                .onUnknownServerNotice(null, date, sMessage, sTarget, sHost);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNames.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNames.java
@@ -145,7 +145,8 @@ public class ProcessNames extends IRCProcessor {
      */
     protected void callChannelTopic(final ChannelInfo cChannel, final boolean bIsJoinTopic) {
         ((IRCChannelInfo) cChannel).setHadTopic();
-        getCallbackManager().getCallbackType(ChannelTopicListener.class).call(cChannel, bIsJoinTopic);
+        getCallbackManager().getCallback(ChannelTopicListener.class)
+                .onChannelTopic(null, null, cChannel, bIsJoinTopic);
     }
 
     /**
@@ -155,7 +156,8 @@ public class ProcessNames extends IRCProcessor {
      * @param cChannel Channel which the names reply is for
      */
     protected void callChannelGotNames(final ChannelInfo cChannel) {
-        getCallbackManager().getCallbackType(ChannelNamesListener.class).call(cChannel);
+        getCallbackManager().getCallback(ChannelNamesListener.class)
+                .onChannelGotNames(null, null, cChannel);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNick.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNick.java
@@ -107,7 +107,8 @@ public class ProcessNick extends IRCProcessor {
      */
     protected void callChannelNickChanged(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sOldNick) {
-        getCallbackManager().getCallbackType(ChannelNickChangeListener.class).call(cChannel, cChannelClient, sOldNick);
+        getCallbackManager().getCallback(ChannelNickChangeListener.class)
+                .onChannelNickChanged(null, null, cChannel, cChannelClient, sOldNick);
     }
 
     /**
@@ -118,7 +119,8 @@ public class ProcessNick extends IRCProcessor {
      * @param sOldNick Nickname before change
      */
     protected void callNickChanged(final ClientInfo cClient, final String sOldNick) {
-        getCallbackManager().getCallbackType(NickChangeListener.class).call(cClient, sOldNick);
+        getCallbackManager().getCallback(NickChangeListener.class)
+                .onNickChanged(null, null, cClient, sOldNick);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNickInUse.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNickInUse.java
@@ -22,7 +22,6 @@
 
 package com.dmdirc.parser.irc.processors;
 
-import com.dmdirc.parser.common.MyInfo;
 import com.dmdirc.parser.interfaces.callbacks.NickInUseListener;
 import com.dmdirc.parser.irc.IRCParser;
 import com.dmdirc.parser.irc.ProcessingManager;
@@ -62,25 +61,7 @@ public class ProcessNickInUse extends IRCProcessor {
      */
     @Override
     public void process(final String sParam, final String... token) {
-        if (!callNickInUse(token[3])) {
-            // Manually handle nick in use.
-            callDebugInfo(IRCParser.DEBUG_INFO, "No Nick in use Handler.");
-            if (!parser.got001) {
-                callDebugInfo(IRCParser.DEBUG_INFO, "Using inbuilt handler");
-                // If this is before 001 we will try and get a nickname, else we will leave the nick as-is
-                final MyInfo myInfo = parser.getMyInfo();
-                if (parser.triedAlt) {
-                    final String magicAltNick = myInfo.getPrependChar() + myInfo.getNickname();
-                    if (parser.getStringConverter().equalsIgnoreCase(parser.thinkNickname, myInfo.getAltNickname()) && !myInfo.getAltNickname().equalsIgnoreCase(magicAltNick)) {
-                        parser.thinkNickname = myInfo.getNickname();
-                    }
-                    parser.getLocalClient().setNickname(myInfo.getPrependChar() + parser.thinkNickname);
-                } else {
-                    parser.getLocalClient().setNickname(parser.getMyInfo().getAltNickname());
-                    parser.triedAlt = true;
-                }
-            }
-        }
+        callNickInUse(token[3]);
     }
 
     /**
@@ -88,10 +69,10 @@ public class ProcessNickInUse extends IRCProcessor {
      *
      * @param nickname Nickname that was wanted.
      * @see NickInUseListener
-     * @return true if a method was called, false otherwise
      */
-    protected boolean callNickInUse(final String nickname) {
-        return getCallbackManager().getCallbackType(NickInUseListener.class).call(nickname);
+    protected void callNickInUse(final String nickname) {
+        getCallbackManager().getCallback(NickInUseListener.class)
+                .onNickInUse(null, null, nickname);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNoticeAuth.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNoticeAuth.java
@@ -59,7 +59,8 @@ public class ProcessNoticeAuth extends IRCProcessor {
      * @param data Incomming Line.
      */
     protected void callNoticeAuth(final String data) {
-        getCallbackManager().getCallbackType(AuthNoticeListener.class).call(data);
+        getCallbackManager().getCallback(AuthNoticeListener.class)
+                .onNoticeAuth(null, null, data);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessPart.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessPart.java
@@ -112,7 +112,8 @@ public class ProcessPart extends IRCProcessor {
      */
     protected void callChannelPart(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sReason) {
-        getCallbackManager().getCallbackType(ChannelPartListener.class).call(cChannel, cChannelClient, sReason);
+        getCallbackManager().getCallback(ChannelPartListener.class)
+                .onChannelPart(null, null, cChannel, cChannelClient, sReason);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessQuit.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessQuit.java
@@ -120,7 +120,8 @@ public class ProcessQuit extends IRCProcessor {
      */
     protected void callChannelQuit(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sReason) {
-        getCallbackManager().getCallbackType(ChannelQuitListener.class).call(cChannel, cChannelClient, sReason);
+        getCallbackManager().getCallback(ChannelQuitListener.class)
+                .onChannelQuit(null, null, cChannel, cChannelClient, sReason);
     }
 
     /**
@@ -131,7 +132,8 @@ public class ProcessQuit extends IRCProcessor {
      * @param sReason Reason for quitting (may be "")
      */
     protected void callQuit(final ClientInfo cClient, final String sReason) {
-        getCallbackManager().getCallbackType(QuitListener.class).call(cClient, sReason);
+        getCallbackManager().getCallback(QuitListener.class)
+                .onQuit(null, null, cClient, sReason);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessTopic.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessTopic.java
@@ -102,7 +102,8 @@ public class ProcessTopic extends IRCProcessor {
      */
     protected void callChannelTopic(final ChannelInfo cChannel, final boolean bIsJoinTopic) {
         ((IRCChannelInfo) cChannel).setHadTopic();
-        getCallbackManager().getCallbackType(ChannelTopicListener.class).call(cChannel, bIsJoinTopic);
+        getCallbackManager().getCallback(ChannelTopicListener.class)
+                .onChannelTopic(null, null, cChannel, bIsJoinTopic);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessWallops.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessWallops.java
@@ -82,7 +82,7 @@ public class ProcessWallops extends IRCProcessor {
      * @param host Host of the user who sent the wallop
      */
     protected void callWallop(final String message, final String host) {
-        getCallbackManager().getCallbackType(WallopListener.class).call(message, host);
+        getCallbackManager().getCallback(WallopListener.class).onWallop(null, null, message, host);
     }
 
     /**
@@ -93,7 +93,8 @@ public class ProcessWallops extends IRCProcessor {
      * @param host Host of the user who sent the walluser
      */
     protected void callWalluser(final String message, final String host) {
-        getCallbackManager().getCallbackType(WalluserListener.class).call(message, host);
+        getCallbackManager().getCallback(WalluserListener.class)
+                .onWalluser(null, null, message, host);
     }
 
     /**
@@ -104,7 +105,8 @@ public class ProcessWallops extends IRCProcessor {
      * @param host Host of the user who sent the WallDesync
      */
     protected void callWallDesync(final String message, final String host) {
-        getCallbackManager().getCallbackType(WallDesyncListener.class).call(message, host);
+        getCallbackManager().getCallback(WallDesyncListener.class)
+                .onWallDesync(null, null, message, host);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessWho.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessWho.java
@@ -106,7 +106,8 @@ public class ProcessWho extends IRCProcessor {
      */
     protected void callAwayState(final AwayState oldState, final AwayState currentState,
             final String reason) {
-        getCallbackManager().getCallbackType(AwayStateListener.class).call(oldState, currentState, reason);
+        getCallbackManager().getCallback(AwayStateListener.class)
+                .onAwayState(null, null, oldState, currentState, reason);
     }
 
     /**
@@ -119,7 +120,8 @@ public class ProcessWho extends IRCProcessor {
      */
     protected void callAwayStateOther(final ClientInfo client, final AwayState oldState,
             final AwayState state) {
-        getCallbackManager().getCallbackType(OtherAwayStateListener.class).call(client, oldState, state);
+        getCallbackManager().getCallback(OtherAwayStateListener.class)
+                .onAwayStateOther(null, null, client, oldState, state);
     }
 
     /**
@@ -133,7 +135,8 @@ public class ProcessWho extends IRCProcessor {
      */
     protected void callChannelAwayStateOther(final ChannelInfo channel,
             final ChannelClientInfo channelClient, final AwayState oldState, final AwayState state) {
-        getCallbackManager().getCallbackType(ChannelOtherAwayStateListener.class).call(channel, channelClient, oldState, state);
+        getCallbackManager().getCallback(ChannelOtherAwayStateListener.class)
+                .onChannelAwayStateOther(null, null, channel, channelClient, oldState, state);
     }
 
     /**


### PR DESCRIPTION
All callbacks are now done through getCallback, which offers
type safety (gasp!) and is potentially extensible in the future
(wow!).

This means that nothing can depend on callbacks existing, so
there are two functional changes:
- the parser will no longer disconnect automatically on failed
  pings; users have to listen for the event and handle it
  themselves;
- the parser will no longer attempt to automatically use alt
  nicknames or create new nicknames on connection; users have to
  listen for the event and implement the logic themselves

Both of these were really weird anyway, as adding a listener (even
for debugging purposes) disabled the built-in behaviour.
