### PR TITLE
Don't expose the CallbackManager to processors.

### DIFF
--- a/irc/src/com/dmdirc/parser/irc/processors/IRCProcessor.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/IRCProcessor.java
@@ -22,9 +22,9 @@
 
 package com.dmdirc.parser.irc.processors;
 
-import com.dmdirc.parser.common.CallbackManager;
 import com.dmdirc.parser.common.ParserError;
 import com.dmdirc.parser.common.QueuePriority;
+import com.dmdirc.parser.interfaces.callbacks.CallbackInterface;
 import com.dmdirc.parser.interfaces.callbacks.DebugInfoListener;
 import com.dmdirc.parser.interfaces.callbacks.ErrorInfoListener;
 import com.dmdirc.parser.irc.IRCChannelInfo;
@@ -120,21 +120,14 @@ public abstract class IRCProcessor {
     }
 
     /**
-     * Get a reference to the CallbackManager.
+     * Gets a callback proxy used to raise events.
      *
-     * @return Reference to the CallbackManager
+     * @param callback The type of callback proxy to retrieve.
+     * @param <T> The type of callback proxy to retrieve.
+     * @return A proxy that can be used to call events.
      */
-    protected final CallbackManager getCallbackManager() {
-        return parser.getCallbackManager();
-    }
-
-    /**
-     * Send a line to the server and add proper line ending.
-     *
-     * @param line Line to send (\r\n termination is added automatically)
-     */
-    protected final void sendString(final String line) {
-        parser.sendString(line);
+    protected <T extends CallbackInterface> T getCallback(final Class<T> callback) {
+        return parser.getCallbackManager().getCallback(callback);
     }
 
     /**
@@ -173,14 +166,6 @@ public abstract class IRCProcessor {
             packageLength = thisPackage.getName().length() + 1;
         }
         return getClass().getName().substring(packageLength);
-    }
-
-    /**
-     * Get the name for this Processor in lowercase.
-     * @return lower case name of this processor
-     */
-    public final String getLowerName() {
-        return getName().toLowerCase();
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/Process004005.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/Process004005.java
@@ -94,7 +94,7 @@ public class Process004005 extends IRCProcessor {
         final String ircdVersion = parser.getServerSoftware();
         final String ircdType = parser.getServerSoftwareType();
 
-        getCallbackManager().getCallback(NetworkDetectedListener.class)
+        getCallback(NetworkDetectedListener.class)
                 .onGotNetwork(null, null, networkName, ircdVersion, ircdType);
     }
 

--- a/irc/src/com/dmdirc/parser/irc/processors/Process464.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/Process464.java
@@ -68,7 +68,6 @@ public class Process464 extends IRCProcessor {
      * @see PasswordRequiredListener
      */
     protected void callPasswordRequired() {
-        getCallbackManager().getCallback(PasswordRequiredListener.class)
-                .onPasswordRequired(null, null);
+        getCallback(PasswordRequiredListener.class).onPasswordRequired(null, null);
     }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessAway.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessAway.java
@@ -90,7 +90,7 @@ public class ProcessAway extends IRCProcessor {
      */
     protected void callAwayState(final AwayState oldState, final AwayState currentState,
             final String reason) {
-        getCallbackManager().getCallback(AwayStateListener.class)
+        getCallback(AwayStateListener.class)
                 .onAwayState(null, null, oldState, currentState, reason);
     }
 

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessInvite.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessInvite.java
@@ -63,8 +63,7 @@ public class ProcessInvite extends IRCProcessor {
      * @param channel The name of the channel we were invited to
      */
     protected void callInvite(final String userHost, final String channel) {
-        getCallbackManager().getCallback(InviteListener.class)
-                .onInvite(null, null, userHost, channel);
+        getCallback(InviteListener.class).onInvite(null, null, userHost, channel);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessJoin.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessJoin.java
@@ -182,8 +182,7 @@ public class ProcessJoin extends IRCProcessor {
      */
     protected void callChannelJoin(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient) {
-        getCallbackManager().getCallback(ChannelJoinListener.class)
-                .onChannelJoin(null, null, cChannel, cChannelClient);
+        getCallback(ChannelJoinListener.class).onChannelJoin(null, null, cChannel, cChannelClient);
     }
 
     /**
@@ -193,8 +192,7 @@ public class ProcessJoin extends IRCProcessor {
      * @param cChannel Channel Object
      */
     protected void callChannelSelfJoin(final ChannelInfo cChannel) {
-        getCallbackManager().getCallback(ChannelSelfJoinListener.class)
-                .onChannelSelfJoin(null, null, cChannel);
+        getCallback(ChannelSelfJoinListener.class).onChannelSelfJoin(null, null, cChannel);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessKick.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessKick.java
@@ -120,7 +120,7 @@ public class ProcessKick extends IRCProcessor {
     protected void callChannelKick(final ChannelInfo cChannel,
             final ChannelClientInfo cKickedClient, final ChannelClientInfo cKickedByClient,
             final String sReason, final String sKickedByHost) {
-        getCallbackManager().getCallback(ChannelKickListener.class)
+        getCallback(ChannelKickListener.class)
                 .onChannelKick(null, null, cChannel, cKickedClient, cKickedByClient, sReason,
                         sKickedByHost);
     }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessList.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessList.java
@@ -56,16 +56,15 @@ public class ProcessList extends IRCProcessor {
         // :port80b.se.quakenet.org 323 MD87 :End of /LIST
         switch (sParam) {
             case "321":
-                getCallbackManager().getCallback(GroupListStartListener.class)
-                        .onGroupListStart(null, null);
+                getCallback(GroupListStartListener.class).onGroupListStart(null, null);
                 break;
             case "322":
-                getCallbackManager().getCallback(GroupListEntryListener.class)
-                        .onGroupListEntry(null, null, token[3], Integer.parseInt(token[4]), token[5]);
+                getCallback(GroupListEntryListener.class)
+                        .onGroupListEntry(null, null, token[3], Integer.parseInt(token[4]),
+                                token[5]);
                 break;
             case "323":
-                getCallbackManager().getCallback(GroupListEndListener.class)
-                        .onGroupListEnd(null, null);
+                getCallback(GroupListEndListener.class).onGroupListEnd(null, null);
                 break;
         }
     }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessListModes.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessListModes.java
@@ -294,7 +294,7 @@ public class ProcessListModes extends IRCProcessor {
      * @param mode the mode that we got list modes for.
      */
     protected void callChannelGotListModes(final ChannelInfo cChannel, final char mode) {
-        getCallbackManager().getCallback(ChannelListModeListener.class)
+        getCallback(ChannelListModeListener.class)
                 .onChannelGotListModes(null, null, cChannel, mode);
     }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessMOTD.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessMOTD.java
@@ -72,8 +72,7 @@ public class ProcessMOTD extends IRCProcessor {
      * @see MotdEndListener
      */
     protected void callMOTDEnd(final boolean noMOTD, final String data) {
-        getCallbackManager().getCallback(MotdEndListener.class)
-                .onMOTDEnd(null, null, noMOTD, data);
+        getCallback(MotdEndListener.class).onMOTDEnd(null, null, noMOTD, data);
     }
 
     /**
@@ -83,8 +82,7 @@ public class ProcessMOTD extends IRCProcessor {
      * @param data Incomming Line.
      */
     protected void callMOTDLine(final String data) {
-        getCallbackManager().getCallback(MotdLineListener.class)
-                .onMOTDLine(null, null, data);
+        getCallback(MotdLineListener.class).onMOTDLine(null, null, data);
     }
 
     /**
@@ -94,8 +92,7 @@ public class ProcessMOTD extends IRCProcessor {
      * @param data Incomming Line.
      */
     protected void callMOTDStart(final String data) {
-        getCallbackManager().getCallback(MotdStartListener.class)
-                .onMOTDStart(null, null, data);
+        getCallback(MotdStartListener.class).onMOTDStart(null, null, data);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessMessage.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessMessage.java
@@ -302,7 +302,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callChannelAction(final Date date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sMessage, final String sHost) {
-        getCallbackManager().getCallback(ChannelActionListener.class)
+        getCallback(ChannelActionListener.class)
                 .onChannelAction(null, date, cChannel, cChannelClient, sMessage, sHost);
     }
 
@@ -320,7 +320,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
     protected void callChannelCTCP(final Date date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sType, final String sMessage,
             final String sHost) {
-        getCallbackManager().getCallback(ChannelCtcpListener.class)
+        getCallback(ChannelCtcpListener.class)
                 .onChannelCTCP(null, date, cChannel, cChannelClient, sType, sMessage, sHost);
     }
 
@@ -338,7 +338,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
     protected void callChannelCTCPReply(final Date date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sType, final String sMessage,
             final String sHost) {
-        getCallbackManager().getCallback(ChannelCtcpReplyListener.class)
+        getCallback(ChannelCtcpReplyListener.class)
                 .onChannelCTCPReply(null, date, cChannel, cChannelClient, sType, sMessage, sHost);
     }
 
@@ -354,7 +354,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callChannelMessage(final Date date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sMessage, final String sHost) {
-        getCallbackManager().getCallback(ChannelMessageListener.class)
+        getCallback(ChannelMessageListener.class)
                 .onChannelMessage(null, date, cChannel, cChannelClient, sMessage, sHost);
     }
 
@@ -370,7 +370,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callChannelNotice(final Date date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sMessage, final String sHost) {
-        getCallbackManager().getCallback(ChannelNoticeListener.class)
+        getCallback(ChannelNoticeListener.class)
                 .onChannelNotice(null, date, cChannel, cChannelClient, sMessage, sHost);
     }
 
@@ -388,7 +388,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
     protected void callChannelModeNotice(final Date date, final char prefix,
             final ChannelInfo cChannel, final ChannelClientInfo cChannelClient,
             final String sMessage, final String sHost) {
-        getCallbackManager().getCallback(ChannelModeNoticeListener.class)
+        getCallback(ChannelModeNoticeListener.class)
                 .onChannelModeNotice(null, date, cChannel, prefix, cChannelClient, sMessage, sHost);
     }
 
@@ -406,7 +406,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
     protected void callChannelModeMessage(final Date date, final char prefix,
             final ChannelInfo cChannel, final ChannelClientInfo cChannelClient,
             final String sMessage, final String sHost) {
-        getCallbackManager().getCallback(ChannelModeMessageListener.class)
+        getCallback(ChannelModeMessageListener.class)
                 .onChannelModeMessage(null, date, cChannel, prefix, cChannelClient, sMessage,
                         sHost);
     }
@@ -420,7 +420,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sHost Hostname of sender (or servername)
      */
     protected void callPrivateAction(final Date date, final String sMessage, final String sHost) {
-        getCallbackManager().getCallback(PrivateActionListener.class)
+        getCallback(PrivateActionListener.class)
                 .onPrivateAction(null, date, sMessage, sHost);
     }
 
@@ -435,7 +435,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callPrivateCTCP(final Date date, final String sType, final String sMessage,
             final String sHost) {
-        getCallbackManager().getCallback(PrivateCtcpListener.class)
+        getCallback(PrivateCtcpListener.class)
                 .onPrivateCTCP(null, date, sType, sMessage, sHost);
     }
 
@@ -450,7 +450,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callPrivateCTCPReply(final Date date, final String sType, final String sMessage,
             final String sHost) {
-        getCallbackManager().getCallback(PrivateCtcpReplyListener.class)
+        getCallback(PrivateCtcpReplyListener.class)
                 .onPrivateCTCPReply(null, date, sType, sMessage, sHost);
     }
 
@@ -463,7 +463,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sHost Hostname of sender (or servername)
      */
     protected void callPrivateMessage(final Date date, final String sMessage, final String sHost) {
-        getCallbackManager().getCallback(PrivateMessageListener.class)
+        getCallback(PrivateMessageListener.class)
                 .onPrivateMessage(null, date, sMessage, sHost);
     }
 
@@ -476,7 +476,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sHost Hostname of sender (or servername)
      */
     protected void callPrivateNotice(final Date date, final String sMessage, final String sHost) {
-        getCallbackManager().getCallback(PrivateNoticeListener.class)
+        getCallback(PrivateNoticeListener.class)
                 .onPrivateNotice(null, date, sMessage, sHost);
     }
 
@@ -489,7 +489,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sHost Hostname of sender (or servername)
      */
     protected void callServerNotice(final Date date, final String sMessage, final String sHost) {
-        getCallbackManager().getCallback(ServerNoticeListener.class)
+        getCallback(ServerNoticeListener.class)
                 .onServerNotice(null, date, sMessage, sHost);
     }
 
@@ -504,7 +504,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownAction(final Date date, final String sMessage, final String sTarget,
             final String sHost) {
-        getCallbackManager().getCallback(UnknownActionListener.class)
+        getCallback(UnknownActionListener.class)
                 .onUnknownAction(null, date, sMessage, sTarget, sHost);
     }
 
@@ -520,7 +520,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownCTCP(final Date date, final String sType, final String sMessage,
             final String sTarget, final String sHost) {
-        getCallbackManager().getCallback(UnknownCtcpListener.class)
+        getCallback(UnknownCtcpListener.class)
                 .onUnknownCTCP(null, date, sType, sMessage, sTarget, sHost);
     }
 
@@ -536,7 +536,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownCTCPReply(final Date date, final String sType, final String sMessage,
             final String sTarget, final String sHost) {
-        getCallbackManager().getCallback(UnknownCtcpReplyListener.class)
+        getCallback(UnknownCtcpReplyListener.class)
                 .onUnknownCTCPReply(null, date, sType, sMessage, sTarget, sHost);
     }
 
@@ -551,7 +551,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownMessage(final Date date, final String sMessage, final String sTarget,
             final String sHost) {
-        getCallbackManager().getCallback(UnknownMessageListener.class)
+        getCallback(UnknownMessageListener.class)
                 .onUnknownMessage(null, date, sMessage, sTarget, sHost);
     }
 
@@ -566,7 +566,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownNotice(final Date date, final String sMessage, final String sTarget,
             final String sHost) {
-        getCallbackManager().getCallback(UnknownNoticeListener.class)
+        getCallback(UnknownNoticeListener.class)
                 .onUnknownNotice(null, date, sMessage, sTarget, sHost);
     }
 
@@ -581,7 +581,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     protected void callUnknownServerNotice(final Date date, final String sMessage,
             final String sTarget, final String sHost) {
-        getCallbackManager().getCallback(UnknownServerNoticeListener.class)
+        getCallback(UnknownServerNoticeListener.class)
                 .onUnknownServerNotice(null, date, sMessage, sTarget, sHost);
     }
 

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessMode.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessMode.java
@@ -228,7 +228,7 @@ public class ProcessMode extends IRCProcessor {
                         iChannel.setListModeParam(cMode, new ChannelListModeItem(sModeParam, token[0], nTemp), bPositive);
                         callDebugInfo(IRCParser.DEBUG_INFO, "List Mode: %c [%s] {Positive: %b}", cMode, sModeParam, bPositive);
                         if (!"324".equals(sParam)) {
-                            getCallbackManager().getCallback(ChannelSingleModeChangeListener.class)
+                            getCallback(ChannelSingleModeChangeListener.class)
                                     .onChannelSingleModeChanged(null, null, iChannel, setterCCI,
                                             token[0], cPositive + cMode + " " + sModeParam);
                         }
@@ -241,7 +241,7 @@ public class ProcessMode extends IRCProcessor {
                             callDebugInfo(IRCParser.DEBUG_INFO, "Set Mode: %c [%s] {Positive: %b}", cMode, sModeParam, bPositive);
                             iChannel.setModeParam(cMode, sModeParam);
                             if (!"324".equals(sParam)) {
-                                getCallbackManager().getCallback(ChannelSingleModeChangeListener.class)
+                                getCallback(ChannelSingleModeChangeListener.class)
                                         .onChannelSingleModeChanged(null, null, iChannel, setterCCI,
                                             token[0], cPositive + cMode + " " + sModeParam);
                             }
@@ -256,7 +256,7 @@ public class ProcessMode extends IRCProcessor {
                             callDebugInfo(IRCParser.DEBUG_INFO, "Unset Mode: %c [%s] {Positive: %b}", cMode, sModeParam, bPositive);
                             iChannel.setModeParam(cMode, "");
                             if (!"324".equals(sParam)) {
-                                getCallbackManager().getCallback(ChannelSingleModeChangeListener.class)
+                                getCallback(ChannelSingleModeChangeListener.class)
                                         .onChannelSingleModeChanged(null, null, iChannel, setterCCI,
                                             token[0], trim(cPositive + cMode + " " + sModeParam));
                             }
@@ -276,7 +276,7 @@ public class ProcessMode extends IRCProcessor {
             callChannelModeChanged(iChannel, null, "", sFullModeStr.toString().trim());
         } else {
             callChannelModeChanged(iChannel, setterCCI, token[0], sFullModeStr.toString().trim());
-            getCallbackManager().getCallback(ChannelNonUserModeChangeListener.class)
+            getCallback(ChannelNonUserModeChangeListener.class)
                     .onChannelNonUserModeChanged(null, null, iChannel, setterCCI, token[0],
                             trim(sNonUserModeStr.toString() + sNonUserModeStrParams));
         }
@@ -345,7 +345,7 @@ public class ProcessMode extends IRCProcessor {
      */
     protected void callChannelModeChanged(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sHost, final String sModes) {
-        getCallbackManager().getCallback(ChannelModeChangeListener.class)
+        getCallback(ChannelModeChangeListener.class)
                 .onChannelModeChanged(null, null, cChannel, cChannelClient, sHost, sModes);
     }
 
@@ -362,7 +362,7 @@ public class ProcessMode extends IRCProcessor {
     protected void callChannelUserModeChanged(final ChannelInfo cChannel,
             final ChannelClientInfo cChangedClient, final ChannelClientInfo cSetByClient,
             final String sHost, final String sMode) {
-        getCallbackManager().getCallback(ChannelUserModeChangeListener.class)
+        getCallback(ChannelUserModeChangeListener.class)
                 .onChannelUserModeChanged(null, null, cChannel, cChangedClient, cSetByClient,
                         sHost, sMode);
     }
@@ -377,7 +377,7 @@ public class ProcessMode extends IRCProcessor {
      */
     protected void callUserModeChanged(final ClientInfo cClient, final String sSetby,
             final String sModes) {
-        getCallbackManager().getCallback(UserModeChangeListener.class)
+        getCallback(UserModeChangeListener.class)
                 .onUserModeChanged(null, null, cClient, sSetby, sModes);
     }
 
@@ -389,7 +389,7 @@ public class ProcessMode extends IRCProcessor {
      * @param sModes The modes set.
      */
     protected void callUserModeDiscovered(final ClientInfo cClient, final String sModes) {
-        getCallbackManager().getCallback(UserModeDiscoveryListener.class)
+        getCallback(UserModeDiscoveryListener.class)
                 .onUserModeDiscovered(null, null, cClient, sModes);
     }
 

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNames.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNames.java
@@ -145,7 +145,7 @@ public class ProcessNames extends IRCProcessor {
      */
     protected void callChannelTopic(final ChannelInfo cChannel, final boolean bIsJoinTopic) {
         ((IRCChannelInfo) cChannel).setHadTopic();
-        getCallbackManager().getCallback(ChannelTopicListener.class)
+        getCallback(ChannelTopicListener.class)
                 .onChannelTopic(null, null, cChannel, bIsJoinTopic);
     }
 
@@ -156,7 +156,7 @@ public class ProcessNames extends IRCProcessor {
      * @param cChannel Channel which the names reply is for
      */
     protected void callChannelGotNames(final ChannelInfo cChannel) {
-        getCallbackManager().getCallback(ChannelNamesListener.class)
+        getCallback(ChannelNamesListener.class)
                 .onChannelGotNames(null, null, cChannel);
     }
 

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNick.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNick.java
@@ -107,7 +107,7 @@ public class ProcessNick extends IRCProcessor {
      */
     protected void callChannelNickChanged(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sOldNick) {
-        getCallbackManager().getCallback(ChannelNickChangeListener.class)
+        getCallback(ChannelNickChangeListener.class)
                 .onChannelNickChanged(null, null, cChannel, cChannelClient, sOldNick);
     }
 
@@ -119,7 +119,7 @@ public class ProcessNick extends IRCProcessor {
      * @param sOldNick Nickname before change
      */
     protected void callNickChanged(final ClientInfo cClient, final String sOldNick) {
-        getCallbackManager().getCallback(NickChangeListener.class)
+        getCallback(NickChangeListener.class)
                 .onNickChanged(null, null, cClient, sOldNick);
     }
 

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNickInUse.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNickInUse.java
@@ -71,7 +71,7 @@ public class ProcessNickInUse extends IRCProcessor {
      * @see NickInUseListener
      */
     protected void callNickInUse(final String nickname) {
-        getCallbackManager().getCallback(NickInUseListener.class)
+        getCallback(NickInUseListener.class)
                 .onNickInUse(null, null, nickname);
     }
 

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNoticeAuth.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNoticeAuth.java
@@ -59,8 +59,7 @@ public class ProcessNoticeAuth extends IRCProcessor {
      * @param data Incomming Line.
      */
     protected void callNoticeAuth(final String data) {
-        getCallbackManager().getCallback(AuthNoticeListener.class)
-                .onNoticeAuth(null, null, data);
+        getCallback(AuthNoticeListener.class).onNoticeAuth(null, null, data);
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessPart.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessPart.java
@@ -112,7 +112,7 @@ public class ProcessPart extends IRCProcessor {
      */
     protected void callChannelPart(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sReason) {
-        getCallbackManager().getCallback(ChannelPartListener.class)
+        getCallback(ChannelPartListener.class)
                 .onChannelPart(null, null, cChannel, cChannelClient, sReason);
     }
 

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessQuit.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessQuit.java
@@ -120,7 +120,7 @@ public class ProcessQuit extends IRCProcessor {
      */
     protected void callChannelQuit(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sReason) {
-        getCallbackManager().getCallback(ChannelQuitListener.class)
+        getCallback(ChannelQuitListener.class)
                 .onChannelQuit(null, null, cChannel, cChannelClient, sReason);
     }
 
@@ -132,7 +132,7 @@ public class ProcessQuit extends IRCProcessor {
      * @param sReason Reason for quitting (may be "")
      */
     protected void callQuit(final ClientInfo cClient, final String sReason) {
-        getCallbackManager().getCallback(QuitListener.class)
+        getCallback(QuitListener.class)
                 .onQuit(null, null, cClient, sReason);
     }
 

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessTopic.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessTopic.java
@@ -102,7 +102,7 @@ public class ProcessTopic extends IRCProcessor {
      */
     protected void callChannelTopic(final ChannelInfo cChannel, final boolean bIsJoinTopic) {
         ((IRCChannelInfo) cChannel).setHadTopic();
-        getCallbackManager().getCallback(ChannelTopicListener.class)
+        getCallback(ChannelTopicListener.class)
                 .onChannelTopic(null, null, cChannel, bIsJoinTopic);
     }
 

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessWallops.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessWallops.java
@@ -82,7 +82,7 @@ public class ProcessWallops extends IRCProcessor {
      * @param host Host of the user who sent the wallop
      */
     protected void callWallop(final String message, final String host) {
-        getCallbackManager().getCallback(WallopListener.class).onWallop(null, null, message, host);
+        getCallback(WallopListener.class).onWallop(null, null, message, host);
     }
 
     /**
@@ -93,7 +93,7 @@ public class ProcessWallops extends IRCProcessor {
      * @param host Host of the user who sent the walluser
      */
     protected void callWalluser(final String message, final String host) {
-        getCallbackManager().getCallback(WalluserListener.class)
+        getCallback(WalluserListener.class)
                 .onWalluser(null, null, message, host);
     }
 
@@ -105,7 +105,7 @@ public class ProcessWallops extends IRCProcessor {
      * @param host Host of the user who sent the WallDesync
      */
     protected void callWallDesync(final String message, final String host) {
-        getCallbackManager().getCallback(WallDesyncListener.class)
+        getCallback(WallDesyncListener.class)
                 .onWallDesync(null, null, message, host);
     }
 

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessWho.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessWho.java
@@ -106,7 +106,7 @@ public class ProcessWho extends IRCProcessor {
      */
     protected void callAwayState(final AwayState oldState, final AwayState currentState,
             final String reason) {
-        getCallbackManager().getCallback(AwayStateListener.class)
+        getCallback(AwayStateListener.class)
                 .onAwayState(null, null, oldState, currentState, reason);
     }
 
@@ -120,7 +120,7 @@ public class ProcessWho extends IRCProcessor {
      */
     protected void callAwayStateOther(final ClientInfo client, final AwayState oldState,
             final AwayState state) {
-        getCallbackManager().getCallback(OtherAwayStateListener.class)
+        getCallback(OtherAwayStateListener.class)
                 .onAwayStateOther(null, null, client, oldState, state);
     }
 
@@ -135,7 +135,7 @@ public class ProcessWho extends IRCProcessor {
      */
     protected void callChannelAwayStateOther(final ChannelInfo channel,
             final ChannelClientInfo channelClient, final AwayState oldState, final AwayState state) {
-        getCallbackManager().getCallback(ChannelOtherAwayStateListener.class)
+        getCallback(ChannelOtherAwayStateListener.class)
                 .onChannelAwayStateOther(null, null, channel, channelClient, oldState, state);
     }
 


### PR DESCRIPTION
Just add a utility method to get the callback proxy instead.

Think this is a bit nicer, and is one less thing to have to change
if we switch to events.
