### PR TITLE
Make IRCProcessor implement handles().

### DIFF
--- a/irc/src/com/dmdirc/parser/irc/TimestampedIRCProcessor.java
+++ b/irc/src/com/dmdirc/parser/irc/TimestampedIRCProcessor.java
@@ -37,9 +37,11 @@ public abstract class TimestampedIRCProcessor extends IRCProcessor {
      *
      * @param parser IRCParser That owns this IRCProcessor
      * @param manager ProcessingManager that is in charge of this IRCProcessor
+     * @param handledTokens Tokens that this processor handles
      */
-    protected TimestampedIRCProcessor(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+    protected TimestampedIRCProcessor(final IRCParser parser, final ProcessingManager manager,
+            final String... handledTokens) {
+        super(parser, manager, handledTokens);
     }
 
     @Override

--- a/irc/src/com/dmdirc/parser/irc/processors/IRCProcessor.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/IRCProcessor.java
@@ -43,6 +43,9 @@ public abstract class IRCProcessor {
     /** Reference to the Processing in charge of this IRCProcessor. */
     protected final ProcessingManager manager;
 
+    /** The names of the tokens this processor handles. */
+    private final String[] handledTokens;
+
     // Some functions from the main parser are useful, and having to use parser.functionName
     // is annoying, so we also implement them here (calling them again using parser)
     /**
@@ -50,10 +53,13 @@ public abstract class IRCProcessor {
      *
      * @param parser IRCParser That owns this IRCProcessor
      * @param manager ProcessingManager that is in charge of this IRCProcessor
+     * @param handledTokens Tokens that this processor handles
      */
-    protected IRCProcessor(final IRCParser parser, final ProcessingManager manager) {
+    protected IRCProcessor(final IRCParser parser, final ProcessingManager manager,
+            final String ... handledTokens) {
         this.parser = parser;
         this.manager = manager;
+        this.handledTokens = handledTokens;
     }
 
     /**
@@ -153,7 +159,9 @@ public abstract class IRCProcessor {
      *
      * @return String[] with the names of the tokens we handle.
      */
-    public abstract String[] handles();
+    public String[] handles() {
+        return handledTokens;
+    }
 
     /**
      * Get the name for this Processor.

--- a/irc/src/com/dmdirc/parser/irc/processors/Process001.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/Process001.java
@@ -41,7 +41,7 @@ public class Process001 extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public Process001(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "001");
     }
 
     /**
@@ -87,13 +87,4 @@ public class Process001 extends IRCProcessor {
         parser.joinChannels(requests.toArray(new ChannelJoinRequest[requests.size()]));
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"001"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/Process004005.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/Process004005.java
@@ -47,7 +47,7 @@ public class Process004005 extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public Process004005(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "002", "003", "004", "005");
     }
 
     /**
@@ -72,16 +72,6 @@ public class Process004005 extends IRCProcessor {
                 process005(token);
                 break;
         }
-    }
-
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"002", "003", "004", "005"};
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/Process464.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/Process464.java
@@ -40,7 +40,7 @@ public class Process464 extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public Process464(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "464");
     }
 
     /**
@@ -52,16 +52,6 @@ public class Process464 extends IRCProcessor {
     @Override
     public void process(final String sParam, final String... token) {
         callPasswordRequired();
-    }
-
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"464"};
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessAccount.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessAccount.java
@@ -38,7 +38,7 @@ public class ProcessAccount extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessAccount(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "ACCOUNT");
     }
 
     /**
@@ -56,13 +56,4 @@ public class ProcessAccount extends IRCProcessor {
         }
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"ACCOUNT"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessAway.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessAway.java
@@ -41,7 +41,7 @@ public class ProcessAway extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessAway(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "301", "305", "306", "AWAY");
     }
 
     /**
@@ -96,13 +96,4 @@ public class ProcessAway extends IRCProcessor {
                 .onAwayState(parser, new Date(), oldState, currentState, reason);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"301", "305", "306", "AWAY"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessCap.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessCap.java
@@ -56,7 +56,7 @@ public class ProcessCap extends TimestampedIRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessCap(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "CAP");
 
         // IRCv3.1 Standard
         supportedCapabilities.add("multi-prefix");
@@ -131,13 +131,4 @@ public class ProcessCap extends TimestampedIRCProcessor {
         }
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"CAP"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessInvite.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessInvite.java
@@ -40,7 +40,7 @@ public class ProcessInvite extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessInvite(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "INVITE");
     }
 
     /**
@@ -68,13 +68,4 @@ public class ProcessInvite extends IRCProcessor {
         getCallback(InviteListener.class).onInvite(parser, new Date(), userHost, channel);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"INVITE"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessJoin.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessJoin.java
@@ -65,7 +65,7 @@ public class ProcessJoin extends IRCProcessor {
     public ProcessJoin(final IRCParser parser, final PrefixModeManager prefixModeManager,
             final ModeManager userModeManager, final ModeManager chanModeManager,
             final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "JOIN", "329");
         this.prefixModeManager = prefixModeManager;
         this.userModeManager = userModeManager;
         this.chanModeManager = chanModeManager;
@@ -197,13 +197,4 @@ public class ProcessJoin extends IRCProcessor {
         getCallback(ChannelSelfJoinListener.class).onChannelSelfJoin(parser, new Date(), cChannel);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"JOIN", "329"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessKick.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessKick.java
@@ -47,7 +47,7 @@ public class ProcessKick extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessKick(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "KICK");
     }
 
     /**
@@ -126,13 +126,4 @@ public class ProcessKick extends IRCProcessor {
                         sReason, sKickedByHost);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"KICK"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessList.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessList.java
@@ -42,7 +42,7 @@ public class ProcessList extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessList(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "321", "322", "323");
     }
 
     /**
@@ -71,13 +71,4 @@ public class ProcessList extends IRCProcessor {
         }
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"321", "322", "323"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessListModes.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessListModes.java
@@ -48,7 +48,19 @@ public class ProcessListModes extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessListModes(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager,
+                "367", "368", /* Bans */
+                "344", "345", /* Reop list (ircnet) or bad words (euirc) */
+                "346", "347", /* Invite List */
+                "348", "349", /* Except/Exempt List */
+                "386", "387", /* Channel Owner List (swiftirc ) */
+                "388", "389", /* Protected User List (swiftirc) */
+                "940", "941", /* Censored words list */
+                "910", "911", /* INSPIRCD Channel Access List. */
+                "954", "953", /* INSPIRCD exemptchanops List. */
+                "482",        /* Permission Denied */
+                "__LISTMODE__" /* Sensible List Modes */
+        );
     }
 
     /**
@@ -265,26 +277,6 @@ public class ProcessListModes extends IRCProcessor {
                 }
             }
         }
-    }
-
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"367", "368", /* Bans */
-                    "344", "345", /* Reop list (ircnet) or bad words (euirc) */
-                    "346", "347", /* Invite List */
-                    "348", "349", /* Except/Exempt List */
-                    "386", "387", /* Channel Owner List (swiftirc ) */
-                    "388", "389", /* Protected User List (swiftirc) */
-                    "940", "941", /* Censored words list */
-                    "910", "911", /* INSPIRCD Channel Access List. */
-                    "954", "953", /* INSPIRCD exemptchanops List. */
-                    "482", /* Permission Denied */
-                    "__LISTMODE__" /* Sensible List Modes */};
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessMOTD.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessMOTD.java
@@ -42,7 +42,7 @@ public class ProcessMOTD extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessMOTD(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "372", "375", "376", "422");
     }
 
     /**
@@ -97,13 +97,4 @@ public class ProcessMOTD extends IRCProcessor {
         getCallback(MotdStartListener.class).onMOTDStart(parser, new Date(), data);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"372", "375", "376", "422"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessMessage.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessMessage.java
@@ -78,7 +78,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      */
     public ProcessMessage(final IRCParser parser, final PrefixModeManager prefixModeManager,
             final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "PRIVMSG", "NOTICE");
         this.prefixModeManager = prefixModeManager;
     }
 
@@ -586,13 +586,4 @@ public class ProcessMessage extends TimestampedIRCProcessor {
                 .onUnknownServerNotice(parser, date, sMessage, sTarget, sHost);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"PRIVMSG", "NOTICE"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessMode.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessMode.java
@@ -68,7 +68,7 @@ public class ProcessMode extends IRCProcessor {
     public ProcessMode(final IRCParser parser, final PrefixModeManager prefixModeManager,
             final ModeManager userModeManager, final ModeManager chanModeManager,
             final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "MODE", "324", "221");
         this.prefixModeManager = prefixModeManager;
         this.userModeManager = userModeManager;
         this.chanModeManager = chanModeManager;
@@ -398,13 +398,4 @@ public class ProcessMode extends IRCProcessor {
                 .onUserModeDiscovered(parser, new Date(), cClient, sModes);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"MODE", "324", "221"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNames.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNames.java
@@ -55,7 +55,7 @@ public class ProcessNames extends IRCProcessor {
      */
     public ProcessNames(final IRCParser parser, final PrefixModeManager prefixModeManager,
             final ModeManager userModeManager, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "353", "366");
         this.prefixModeManager = prefixModeManager;
         this.userModeManager = userModeManager;
     }
@@ -162,13 +162,4 @@ public class ProcessNames extends IRCProcessor {
                 .onChannelGotNames(parser, new Date(), cChannel);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"353", "366"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNick.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNick.java
@@ -48,7 +48,7 @@ public class ProcessNick extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessNick(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "NICK");
     }
 
     /**
@@ -125,13 +125,4 @@ public class ProcessNick extends IRCProcessor {
                 .onNickChanged(parser, new Date(), cClient, sOldNick);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"NICK"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNickInUse.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNickInUse.java
@@ -46,7 +46,7 @@ public class ProcessNickInUse extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this object
      */
     public ProcessNickInUse(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "433");
     }
 
     /**
@@ -77,13 +77,4 @@ public class ProcessNickInUse extends IRCProcessor {
                 .onNickInUse(parser, new Date(), nickname);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"433"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNoticeAuth.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNoticeAuth.java
@@ -40,7 +40,7 @@ public class ProcessNoticeAuth extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this object
      */
     public ProcessNoticeAuth(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "Notice Auth");
     }
 
     /**
@@ -64,13 +64,4 @@ public class ProcessNoticeAuth extends IRCProcessor {
         getCallback(AuthNoticeListener.class).onNoticeAuth(parser, new Date(), data);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"Notice Auth"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessPart.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessPart.java
@@ -46,7 +46,7 @@ public class ProcessPart extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessPart(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "PART");
     }
 
     /**
@@ -118,13 +118,4 @@ public class ProcessPart extends IRCProcessor {
                 .onChannelPart(parser, new Date(), cChannel, cChannelClient, sReason);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"PART"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessQuit.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessQuit.java
@@ -48,7 +48,7 @@ public class ProcessQuit extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessQuit(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "QUIT");
     }
 
     /**
@@ -137,13 +137,4 @@ public class ProcessQuit extends IRCProcessor {
                 .onQuit(parser, new Date(), cClient, sReason);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"QUIT"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessTopic.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessTopic.java
@@ -43,7 +43,7 @@ public class ProcessTopic extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessTopic(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "TOPIC", "332", "333");
     }
 
     /**
@@ -108,13 +108,4 @@ public class ProcessTopic extends IRCProcessor {
                 .onChannelTopic(parser, new Date(), cChannel, bIsJoinTopic);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"TOPIC", "332", "333"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessWallops.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessWallops.java
@@ -42,7 +42,7 @@ public class ProcessWallops extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessWallops(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "WALLOPS");
     }
 
     /**
@@ -111,13 +111,4 @@ public class ProcessWallops extends IRCProcessor {
                 .onWallDesync(parser, new Date(), message, host);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"WALLOPS"};
-    }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessWho.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessWho.java
@@ -47,7 +47,7 @@ public class ProcessWho extends IRCProcessor {
      * @param manager ProcessingManager that is in charge of this IRCProcessor
      */
     public ProcessWho(final IRCParser parser, final ProcessingManager manager) {
-        super(parser, manager);
+        super(parser, manager, "352");
     }
 
     /**
@@ -142,13 +142,4 @@ public class ProcessWho extends IRCProcessor {
                         state);
     }
 
-    /**
-     * What does this IRCProcessor handle.
-     *
-     * @return String[] with the names of the tokens we handle.
-     */
-    @Override
-    public String[] handles() {
-        return new String[]{"352"};
-    }
 }


### PR DESCRIPTION
Seems a bit odd for each implementation to define a method that
_always_ returns a static String[] when we can just pass that
up to the base class.
