### PR TITLE
Build process tidying.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,12 +140,12 @@ def find(name) {
 buildscript {
     repositories {
         mavenCentral()
-        maven { url 'https://dl.bintray.com/dmdirc/releases/' }
+        jcenter()
     }
 
     dependencies {
         classpath group: 'com.dmdirc', name: 'git-version', version: '1.0'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.1.0'
+        classpath group: 'org.kt3k.gradle.plugin', name: 'coveralls-gradle-plugin', version: '2.1.0'
     }
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,4 @@ dependencies:
 
 test:
   override:
-    - ./gradlew check
-  post:
-    - ./gradlew coveralls
+    - ./gradlew test jacocoTestReport coveralls

--- a/gradle/coveralls.gradle
+++ b/gradle/coveralls.gradle
@@ -11,15 +11,11 @@ task jacocoRootReport(type: JacocoReport, group: 'Coverage reports', dependsOn: 
   additionalSourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs)
   sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
   classDirectories = files(subprojects.sourceSets.main.output)
-  executionData = files(subprojects.jacocoTestReport.executionData)
+  executionData = files(subprojects.jacocoTestReport.executionData).filter { it.exists() }
 
   reports {
     html.enabled = true
     xml.enabled = true
-  }
-
-  doFirst {
-    executionData = files(executionData.findAll { it.exists() })
   }
 }
 


### PR DESCRIPTION
- Execute coveralls as part of tests, not afterwards
- Update script to plugins version to allow for files that don't exist
- Use jcenter for DMDirc plugin, to stop idea complaining