### PR TITLE
Stop circle build failing.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,11 @@ machine:
   environment:
     TERM: dumb
 
+checkout:
+  post:
+    - "if [ -e .git/shallow ]; then git fetch --unshallow; fi"
+    - git fetch --tags
+
 dependencies:
   override:
     - ./gradlew dependencies


### PR DESCRIPTION
Unshallow the git repository if necessary, and fetch tags.

Both of these things are useful for versioning.