### PR TITLE
Modes should default to "" not null

### DIFF
--- a/irc/src/com/dmdirc/parser/irc/IRCChannelInfo.java
+++ b/irc/src/com/dmdirc/parser/irc/IRCChannelInfo.java
@@ -61,7 +61,7 @@ public class IRCChannelInfo implements ChannelInfo {
     /** Has this channel ever had a topic? */
     private boolean hadTopic;
     /** Known boolean-modes for channel. */
-    private String modes;
+    private String modes = "";
     /** Reference to the parser object that owns this channel, Used for modes. */
     private final IRCParser parser;
     /** Mode manager to use for user modes. */


### PR DESCRIPTION
Hybrid seems to send a MODE message before the 324 which causes an error (https://sentry.dmdirc.com/dmdirc/dmdirc/group/306/). This fixes it.