### PR TITLE
Set ADDRESS and REAL_NAME property after whois.

### DIFF
--- a/irc/src/com/dmdirc/parser/irc/WhoisResponseHandler.java
+++ b/irc/src/com/dmdirc/parser/irc/WhoisResponseHandler.java
@@ -65,6 +65,11 @@ public class WhoisResponseHandler {
     void handleStartOfWhois(final NumericEvent event) {
         client = event.getToken()[3];
         info.clear();
+
+        // :server 311 DMDirc User ~Ident host.dmdirc.com * :Real name
+        info.put(UserInfoType.ADDRESS,
+                event.getToken()[3] + '!' + event.getToken()[4] + '@' + event.getToken()[5]);
+        info.put(UserInfoType.REAL_NAME, event.getToken()[7]);
     }
 
     @Handler(condition = "msg.numeric == 318")
@@ -79,14 +84,6 @@ public class WhoisResponseHandler {
     void handleAwayMessage(final NumericEvent event) {
         // :server 301 DMDirc User :away message
         info.put(UserInfoType.AWAY_MESSAGE, event.getToken()[4]);
-    }
-
-    @Handler(condition = "msg.numeric == 311")
-    void handleUserInfo(final NumericEvent event) {
-        // :server 311 DMDirc User ~Ident host.dmdirc.com * :Real name
-        info.put(UserInfoType.ADDRESS,
-                event.getToken()[3] + '!' + event.getToken()[4] + '@' + event.getToken()[5]);
-        info.put(UserInfoType.REAL_NAME, event.getToken()[7]);
     }
 
     @Handler(condition = "msg.numeric == 312")


### PR DESCRIPTION
Having two separate events means the ordering isn't guaranteed.
Handle everything for 311 numerics in one handler.