### PR TITLE
Migrate parser events to use new date APIs.

### DIFF
--- a/common/src/com/dmdirc/parser/common/BaseParser.java
+++ b/common/src/com/dmdirc/parser/common/BaseParser.java
@@ -32,7 +32,7 @@ import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import net.engio.mbassy.bus.error.PublicationError;
@@ -101,7 +101,7 @@ public abstract class BaseParser extends ThreadedParser {
         }
 
         synchronized (errorHandlerLock) {
-            callbackManager.publish(new ParserErrorEvent(this, new Date(), e.getCause()));
+            callbackManager.publish(new ParserErrorEvent(this, LocalDateTime.now(), e.getCause()));
         }
     }
 

--- a/common/src/com/dmdirc/parser/events/AuthNoticeEvent.java
+++ b/common/src/com/dmdirc/parser/events/AuthNoticeEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -35,7 +35,7 @@ public class AuthNoticeEvent extends ParserEvent {
 
     private final String message;
 
-    public AuthNoticeEvent(final Parser parser, final Date date, final String message) {
+    public AuthNoticeEvent(final Parser parser, final LocalDateTime date, final String message) {
         super(parser, date);
         this.message = checkNotNull(message);
     }

--- a/common/src/com/dmdirc/parser/events/AwayStateEvent.java
+++ b/common/src/com/dmdirc/parser/events/AwayStateEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.common.AwayState;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.annotation.Nullable;
 
@@ -40,7 +40,7 @@ public class AwayStateEvent extends ParserEvent {
     private final AwayState newState;
     private final String reason;
 
-    public AwayStateEvent(final Parser parser, final Date date, final AwayState oldState,
+    public AwayStateEvent(final Parser parser, final LocalDateTime date, final AwayState oldState,
             final AwayState newState, @Nullable final String reason) {
         super(parser, date);
         this.oldState = checkNotNull(oldState);

--- a/common/src/com/dmdirc/parser/events/ChannelActionEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelActionEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -40,8 +40,9 @@ public class ChannelActionEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public ChannelActionEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final ChannelClientInfo client, final String message, final String host) {
+    public ChannelActionEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final ChannelClientInfo client, final String message,
+            final String host) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/ChannelCTCPEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelCTCPEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -41,9 +41,9 @@ public class ChannelCTCPEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public ChannelCTCPEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final ChannelClientInfo client, final String type, final String message,
-            final String host) {
+    public ChannelCTCPEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final ChannelClientInfo client, final String type,
+            final String message, final String host) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/ChannelCTCPReplyEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelCTCPReplyEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -41,9 +41,9 @@ public class ChannelCTCPReplyEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public ChannelCTCPReplyEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final ChannelClientInfo client, final String type, final String message,
-            final String host) {
+    public ChannelCTCPReplyEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final ChannelClientInfo client, final String type,
+            final String message, final String host) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/ChannelJoinEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelJoinEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -38,8 +38,8 @@ public class ChannelJoinEvent extends ParserEvent {
     private final ChannelInfo channel;
     private final ChannelClientInfo client;
 
-    public ChannelJoinEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final ChannelClientInfo client) {
+    public ChannelJoinEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final ChannelClientInfo client) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/ChannelKickEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelKickEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -41,7 +41,7 @@ public class ChannelKickEvent extends ParserEvent {
     private final String reason;
     private final String host;
 
-    public ChannelKickEvent(final Parser parser, final Date date, final ChannelInfo channel,
+    public ChannelKickEvent(final Parser parser, final LocalDateTime date, final ChannelInfo channel,
             final ChannelClientInfo kickedClient, final ChannelClientInfo client,
             final String reason, final String host) {
         super(parser, date);

--- a/common/src/com/dmdirc/parser/events/ChannelListModeEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelListModeEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,8 +37,8 @@ public class ChannelListModeEvent extends ParserEvent {
     private final ChannelInfo channel;
     private final char mode;
 
-    public ChannelListModeEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final char mode) {
+    public ChannelListModeEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final char mode) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.mode = mode;

--- a/common/src/com/dmdirc/parser/events/ChannelMessageEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelMessageEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -40,8 +40,9 @@ public class ChannelMessageEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public ChannelMessageEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final ChannelClientInfo client, final String message, final String host) {
+    public ChannelMessageEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final ChannelClientInfo client, final String message,
+            final String host) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/ChannelModeChangeEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelModeChangeEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -40,8 +40,9 @@ public class ChannelModeChangeEvent extends ParserEvent {
     private final String host;
     private final String modes;
 
-    public ChannelModeChangeEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final ChannelClientInfo client, final String host, final String modes) {
+    public ChannelModeChangeEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final ChannelClientInfo client, final String host,
+            final String modes) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/ChannelModeMessageEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelModeMessageEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -41,9 +41,9 @@ public class ChannelModeMessageEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public ChannelModeMessageEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final char prefix, final ChannelClientInfo client, final String message,
-            final String host) {
+    public ChannelModeMessageEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final char prefix, final ChannelClientInfo client,
+            final String message, final String host) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.prefix = checkNotNull(prefix);

--- a/common/src/com/dmdirc/parser/events/ChannelModeNoticeEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelModeNoticeEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -41,9 +41,9 @@ public class ChannelModeNoticeEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public ChannelModeNoticeEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final char prefix, final ChannelClientInfo client, final String message,
-            final String host) {
+    public ChannelModeNoticeEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final char prefix, final ChannelClientInfo client,
+            final String message, final String host) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.prefix = checkNotNull(prefix);

--- a/common/src/com/dmdirc/parser/events/ChannelNamesEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelNamesEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,8 @@ public class ChannelNamesEvent extends ParserEvent {
 
     private final ChannelInfo channel;
 
-    public ChannelNamesEvent(final Parser parser, final Date date, final ChannelInfo channel) {
+    public ChannelNamesEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel) {
         super(parser, date);
         this.channel = checkNotNull(channel);
     }

--- a/common/src/com/dmdirc/parser/events/ChannelNickChangeEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelNickChangeEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -39,8 +39,8 @@ public class ChannelNickChangeEvent extends ParserEvent {
     private final ChannelClientInfo client;
     private final String oldNick;
 
-    public ChannelNickChangeEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final ChannelClientInfo client, final String oldNick) {
+    public ChannelNickChangeEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final ChannelClientInfo client, final String oldNick) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/ChannelNonUserModeChangeEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelNonUserModeChangeEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -40,7 +40,7 @@ public class ChannelNonUserModeChangeEvent extends ParserEvent {
     private final String host;
     private final String modes;
 
-    public ChannelNonUserModeChangeEvent(final Parser parser, final Date date,
+    public ChannelNonUserModeChangeEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String host,
             final String modes) {
         super(parser, date);

--- a/common/src/com/dmdirc/parser/events/ChannelNoticeEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelNoticeEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -40,8 +40,9 @@ public class ChannelNoticeEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public ChannelNoticeEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final ChannelClientInfo client, final String message, final String host) {
+    public ChannelNoticeEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final ChannelClientInfo client, final String message,
+            final String host) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/ChannelOtherAwayStateEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelOtherAwayStateEvent.java
@@ -27,7 +27,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -41,7 +41,7 @@ public class ChannelOtherAwayStateEvent extends ParserEvent {
     private final AwayState oldState;
     private final AwayState newState;
 
-    public ChannelOtherAwayStateEvent(final Parser parser, final Date date,
+    public ChannelOtherAwayStateEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final AwayState oldState,
             final AwayState newState) {
         super(parser, date);

--- a/common/src/com/dmdirc/parser/events/ChannelPartEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelPartEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -39,8 +39,8 @@ public class ChannelPartEvent extends ParserEvent {
     private final ChannelClientInfo client;
     private final String reason;
 
-    public ChannelPartEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final ChannelClientInfo client, final String reason) {
+    public ChannelPartEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final ChannelClientInfo client, final String reason) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/ChannelQuitEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelQuitEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -39,8 +39,8 @@ public class ChannelQuitEvent extends ParserEvent {
     private final ChannelClientInfo client;
     private final String reason;
 
-    public ChannelQuitEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final ChannelClientInfo client, final String reason) {
+    public ChannelQuitEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final ChannelClientInfo client, final String reason) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/ChannelSelfJoinEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelSelfJoinEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,8 @@ public class ChannelSelfJoinEvent extends ParserEvent {
 
     private final ChannelInfo channel;
 
-    public ChannelSelfJoinEvent(final Parser parser, final Date date, final ChannelInfo channel) {
+    public ChannelSelfJoinEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel) {
         super(parser, date);
         this.channel = checkNotNull(channel);
     }

--- a/common/src/com/dmdirc/parser/events/ChannelSingleModeChangeEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelSingleModeChangeEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -40,7 +40,7 @@ public class ChannelSingleModeChangeEvent extends ParserEvent {
     private final String host;
     private final String modes;
 
-    public ChannelSingleModeChangeEvent(final Parser parser, final Date date,
+    public ChannelSingleModeChangeEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String host,
             final String modes) {
         super(parser, date);

--- a/common/src/com/dmdirc/parser/events/ChannelTopicEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelTopicEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,8 +37,8 @@ public class ChannelTopicEvent extends ParserEvent {
     private final ChannelInfo channel;
     private final boolean isJoinTopic;
 
-    public ChannelTopicEvent(final Parser parser, final Date date, final ChannelInfo channel,
-            final boolean isJoinTopic) {
+    public ChannelTopicEvent(final Parser parser, final LocalDateTime date,
+            final ChannelInfo channel, final boolean isJoinTopic) {
         super(parser, date);
         this.channel = checkNotNull(channel);
         this.isJoinTopic = isJoinTopic;

--- a/common/src/com/dmdirc/parser/events/ChannelUserModeChangeEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelUserModeChangeEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -41,7 +41,7 @@ public class ChannelUserModeChangeEvent extends ParserEvent {
     private final String host;
     private final String mode;
 
-    public ChannelUserModeChangeEvent(final Parser parser, final Date date,
+    public ChannelUserModeChangeEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo targetClient,
             final ChannelClientInfo client, final String host, final String mode) {
         super(parser, date);

--- a/common/src/com/dmdirc/parser/events/CompositionStateChangeEvent.java
+++ b/common/src/com/dmdirc/parser/events/CompositionStateChangeEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.common.CompositionState;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,7 +37,7 @@ public class CompositionStateChangeEvent extends ParserEvent {
     private final CompositionState state;
     private final String host;
 
-    public CompositionStateChangeEvent(final Parser parser, final Date date,
+    public CompositionStateChangeEvent(final Parser parser, final LocalDateTime date,
             final CompositionState state, final String host) {
         super(parser, date);
         this.state = checkNotNull(state);

--- a/common/src/com/dmdirc/parser/events/ConnectErrorEvent.java
+++ b/common/src/com/dmdirc/parser/events/ConnectErrorEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.common.ParserError;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,8 @@ public class ConnectErrorEvent extends ParserEvent {
 
     private final ParserError errorInfo;
 
-    public ConnectErrorEvent(final Parser parser, final Date date, final ParserError errorInfo) {
+    public ConnectErrorEvent(final Parser parser, final LocalDateTime date,
+            final ParserError errorInfo) {
         super(parser, date);
         this.errorInfo = checkNotNull(errorInfo);
     }

--- a/common/src/com/dmdirc/parser/events/DataInEvent.java
+++ b/common/src/com/dmdirc/parser/events/DataInEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -35,7 +35,7 @@ public class DataInEvent extends ParserEvent {
 
     private final String data;
 
-    public DataInEvent(final Parser parser, final Date date, final String data) {
+    public DataInEvent(final Parser parser, final LocalDateTime date, final String data) {
         super(parser, date);
         this.data = checkNotNull(data);
     }

--- a/common/src/com/dmdirc/parser/events/DataOutEvent.java
+++ b/common/src/com/dmdirc/parser/events/DataOutEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -35,7 +35,7 @@ public class DataOutEvent extends ParserEvent {
 
     private final String data;
 
-    public DataOutEvent(final Parser parser, final Date date, final String data) {
+    public DataOutEvent(final Parser parser, final LocalDateTime date, final String data) {
         super(parser, date);
         this.data = checkNotNull(data);
     }

--- a/common/src/com/dmdirc/parser/events/DebugInfoEvent.java
+++ b/common/src/com/dmdirc/parser/events/DebugInfoEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public class DebugInfoEvent extends ParserEvent {
     private final int level;
     private final String data;
 
-    public DebugInfoEvent(final Parser parser, final Date date, final int level,
+    public DebugInfoEvent(final Parser parser, final LocalDateTime date, final int level,
             final String data) {
         super(parser, date);
         this.level = level;

--- a/common/src/com/dmdirc/parser/events/ErrorInfoEvent.java
+++ b/common/src/com/dmdirc/parser/events/ErrorInfoEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.common.ParserError;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,8 @@ public class ErrorInfoEvent extends ParserEvent {
 
     private final ParserError errorInfo;
 
-    public ErrorInfoEvent(final Parser parser, final Date date, final ParserError errorInfo) {
+    public ErrorInfoEvent(final Parser parser, final LocalDateTime date,
+            final ParserError errorInfo) {
         super(parser, date);
         this.errorInfo = checkNotNull(errorInfo);
     }

--- a/common/src/com/dmdirc/parser/events/GroupListEndEvent.java
+++ b/common/src/com/dmdirc/parser/events/GroupListEndEvent.java
@@ -24,14 +24,14 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 /**
  * Callback interface for when the parser receives the end of a group list response.
  */
 public class GroupListEndEvent extends ParserEvent {
 
-    public GroupListEndEvent(final Parser parser, final Date date) {
+    public GroupListEndEvent(final Parser parser, final LocalDateTime date) {
         super(parser, date);
     }
 }

--- a/common/src/com/dmdirc/parser/events/GroupListEntryEvent.java
+++ b/common/src/com/dmdirc/parser/events/GroupListEntryEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,7 +37,7 @@ public class GroupListEntryEvent extends ParserEvent {
     private final int users;
     private final String topic;
 
-    public GroupListEntryEvent(final Parser parser, final Date date, final String name,
+    public GroupListEntryEvent(final Parser parser, final LocalDateTime date, final String name,
             final int users, final String topic) {
         super(parser, date);
         this.name = checkNotNull(name);

--- a/common/src/com/dmdirc/parser/events/GroupListStartEvent.java
+++ b/common/src/com/dmdirc/parser/events/GroupListStartEvent.java
@@ -24,14 +24,14 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 /**
  * Callback interface for when the parser receives the start of a group list response.
  */
 public class GroupListStartEvent extends ParserEvent {
 
-    public GroupListStartEvent(final Parser parser, final Date date) {
+    public GroupListStartEvent(final Parser parser, final LocalDateTime date) {
         super(parser, date);
     }
 }

--- a/common/src/com/dmdirc/parser/events/InviteEvent.java
+++ b/common/src/com/dmdirc/parser/events/InviteEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public class InviteEvent extends ParserEvent {
     private final String userHost;
     private final String channel;
 
-    public InviteEvent(final Parser parser, final Date date, final String userHost,
+    public InviteEvent(final Parser parser, final LocalDateTime date, final String userHost,
             final String channel) {
         super(parser, date);
         this.userHost = checkNotNull(userHost);

--- a/common/src/com/dmdirc/parser/events/MOTDEndEvent.java
+++ b/common/src/com/dmdirc/parser/events/MOTDEndEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public class MOTDEndEvent extends ParserEvent {
     private final boolean noMOTD;
     private final String data;
 
-    public MOTDEndEvent(final Parser parser, final Date date, final boolean noMOTD,
+    public MOTDEndEvent(final Parser parser, final LocalDateTime date, final boolean noMOTD,
             final String data) {
         super(parser, date);
         this.noMOTD = noMOTD;

--- a/common/src/com/dmdirc/parser/events/MOTDLineEvent.java
+++ b/common/src/com/dmdirc/parser/events/MOTDLineEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -35,7 +35,7 @@ public class MOTDLineEvent extends ParserEvent {
 
     private final String data;
 
-    public MOTDLineEvent(final Parser parser, final Date date, final String data) {
+    public MOTDLineEvent(final Parser parser, final LocalDateTime date, final String data) {
         super(parser, date);
         this.data = checkNotNull(data);
     }

--- a/common/src/com/dmdirc/parser/events/MOTDStartEvent.java
+++ b/common/src/com/dmdirc/parser/events/MOTDStartEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -35,7 +35,7 @@ public class MOTDStartEvent extends ParserEvent {
 
     private final String data;
 
-    public MOTDStartEvent(final Parser parser, final Date date, final String data) {
+    public MOTDStartEvent(final Parser parser, final LocalDateTime date, final String data) {
         super(parser, date);
         this.data = checkNotNull(data);
     }

--- a/common/src/com/dmdirc/parser/events/NetworkDetectedEvent.java
+++ b/common/src/com/dmdirc/parser/events/NetworkDetectedEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,8 +37,8 @@ public class NetworkDetectedEvent extends ParserEvent {
     private final String ircdVersion;
     private final String ircdType;
 
-    public NetworkDetectedEvent(final Parser parser, final Date date, final String networkName,
-            final String ircdVersion, final String ircdType) {
+    public NetworkDetectedEvent(final Parser parser, final LocalDateTime date,
+            final String networkName, final String ircdVersion, final String ircdType) {
         super(parser, date);
         this.networkName = checkNotNull(networkName);
         this.ircdVersion = checkNotNull(ircdVersion);

--- a/common/src/com/dmdirc/parser/events/NickChangeEvent.java
+++ b/common/src/com/dmdirc/parser/events/NickChangeEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.interfaces.ClientInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,7 +37,7 @@ public class NickChangeEvent extends ParserEvent {
     private final ClientInfo client;
     private final String oldNick;
 
-    public NickChangeEvent(final Parser parser, final Date date, final ClientInfo client,
+    public NickChangeEvent(final Parser parser, final LocalDateTime date, final ClientInfo client,
             final String oldNick) {
         super(parser, date);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/NickInUseEvent.java
+++ b/common/src/com/dmdirc/parser/events/NickInUseEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -35,7 +35,7 @@ public class NickInUseEvent extends ParserEvent {
 
     private final String nickname;
 
-    public NickInUseEvent(final Parser parser, final Date date, final String nickname) {
+    public NickInUseEvent(final Parser parser, final LocalDateTime date, final String nickname) {
         super(parser, date);
         this.nickname = checkNotNull(nickname);
     }

--- a/common/src/com/dmdirc/parser/events/NumericEvent.java
+++ b/common/src/com/dmdirc/parser/events/NumericEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public class NumericEvent extends ParserEvent {
     private final int numeric;
     private final String[] token;
 
-    public NumericEvent(final Parser parser, final Date date, final int numeric,
+    public NumericEvent(final Parser parser, final LocalDateTime date, final int numeric,
             final String[] token) {
         super(parser, date);
         this.numeric = checkNotNull(numeric);

--- a/common/src/com/dmdirc/parser/events/OtherAwayStateEvent.java
+++ b/common/src/com/dmdirc/parser/events/OtherAwayStateEvent.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.common.AwayState;
 import com.dmdirc.parser.interfaces.ClientInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -39,8 +39,8 @@ public class OtherAwayStateEvent extends ParserEvent {
     private final AwayState oldState;
     private final AwayState newState;
 
-    public OtherAwayStateEvent(final Parser parser, final Date date, final ClientInfo client,
-            final AwayState oldState, final AwayState newState) {
+    public OtherAwayStateEvent(final Parser parser, final LocalDateTime date,
+            final ClientInfo client, final AwayState oldState, final AwayState newState) {
         super(parser, date);
         this.client = checkNotNull(client);
         this.oldState = checkNotNull(oldState);

--- a/common/src/com/dmdirc/parser/events/ParserErrorEvent.java
+++ b/common/src/com/dmdirc/parser/events/ParserErrorEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -35,7 +35,8 @@ public class ParserErrorEvent extends ParserEvent {
 
     private final Throwable throwable;
 
-    public ParserErrorEvent(final Parser parser, final Date date, final Throwable throwable) {
+    public ParserErrorEvent(final Parser parser, final LocalDateTime date,
+            final Throwable throwable) {
         super(parser, date);
         this.throwable = checkNotNull(throwable);
     }

--- a/common/src/com/dmdirc/parser/events/ParserEvent.java
+++ b/common/src/com/dmdirc/parser/events/ParserEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -34,9 +34,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class ParserEvent {
 
     private final Parser parser;
-    private final Date date;
+    private final LocalDateTime date;
 
-    public ParserEvent(final Parser parser, final Date date) {
+    public ParserEvent(final Parser parser, final LocalDateTime date) {
         this.parser = checkNotNull(parser);
         this.date = checkNotNull(date);
     }
@@ -45,7 +45,7 @@ public abstract class ParserEvent {
         return parser;
     }
 
-    public Date getDate() {
+    public LocalDateTime getDate() {
         return date;
     }
 

--- a/common/src/com/dmdirc/parser/events/PasswordRequiredEvent.java
+++ b/common/src/com/dmdirc/parser/events/PasswordRequiredEvent.java
@@ -24,14 +24,14 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 /**
  * Interface Used when a raw 464 is recieved.
  */
 public class PasswordRequiredEvent extends ParserEvent {
 
-    public PasswordRequiredEvent(final Parser parser, final Date date) {
+    public PasswordRequiredEvent(final Parser parser, final LocalDateTime date) {
         super(parser, date);
     }
 }

--- a/common/src/com/dmdirc/parser/events/PingFailureEvent.java
+++ b/common/src/com/dmdirc/parser/events/PingFailureEvent.java
@@ -24,14 +24,14 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 /**
  * Called when a Ping Failed.
  */
 public class PingFailureEvent extends ParserEvent {
 
-    public PingFailureEvent(final Parser parser, final Date date) {
+    public PingFailureEvent(final Parser parser, final LocalDateTime date) {
         super(parser, date);
     }
 }

--- a/common/src/com/dmdirc/parser/events/PingSentEvent.java
+++ b/common/src/com/dmdirc/parser/events/PingSentEvent.java
@@ -24,14 +24,14 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 /**
  * Called when a Ping was Sent.
  */
 public class PingSentEvent extends ParserEvent {
 
-    public PingSentEvent(final Parser parser, final Date date) {
+    public PingSentEvent(final Parser parser, final LocalDateTime date) {
         super(parser, date);
     }
 }

--- a/common/src/com/dmdirc/parser/events/PingSuccessEvent.java
+++ b/common/src/com/dmdirc/parser/events/PingSuccessEvent.java
@@ -24,14 +24,14 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 /**
  * Called when a Ping was a Success.
  */
 public class PingSuccessEvent extends ParserEvent {
 
-    public PingSuccessEvent(final Parser parser, final Date date) {
+    public PingSuccessEvent(final Parser parser, final LocalDateTime date) {
         super(parser, date);
     }
 }

--- a/common/src/com/dmdirc/parser/events/PrivateActionEvent.java
+++ b/common/src/com/dmdirc/parser/events/PrivateActionEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public class PrivateActionEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public PrivateActionEvent(final Parser parser, final Date date, final String message,
+    public PrivateActionEvent(final Parser parser, final LocalDateTime date, final String message,
             final String host) {
         super(parser, date);
         this.message = checkNotNull(message);

--- a/common/src/com/dmdirc/parser/events/PrivateCTCPEvent.java
+++ b/common/src/com/dmdirc/parser/events/PrivateCTCPEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,7 +37,7 @@ public class PrivateCTCPEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public PrivateCTCPEvent(final Parser parser, final Date date, final String type,
+    public PrivateCTCPEvent(final Parser parser, final LocalDateTime date, final String type,
             final String message, final String host) {
         super(parser, date);
         this.type = checkNotNull(type);

--- a/common/src/com/dmdirc/parser/events/PrivateCTCPReplyEvent.java
+++ b/common/src/com/dmdirc/parser/events/PrivateCTCPReplyEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,7 +37,7 @@ public class PrivateCTCPReplyEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public PrivateCTCPReplyEvent(final Parser parser, final Date date, final String type,
+    public PrivateCTCPReplyEvent(final Parser parser, final LocalDateTime date, final String type,
             final String message, final String host) {
         super(parser, date);
         this.type = checkNotNull(type);

--- a/common/src/com/dmdirc/parser/events/PrivateMessageEvent.java
+++ b/common/src/com/dmdirc/parser/events/PrivateMessageEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public class PrivateMessageEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public PrivateMessageEvent(final Parser parser, final Date date, final String message,
+    public PrivateMessageEvent(final Parser parser, final LocalDateTime date, final String message,
             final String host) {
         super(parser, date);
         this.message = checkNotNull(message);

--- a/common/src/com/dmdirc/parser/events/PrivateNoticeEvent.java
+++ b/common/src/com/dmdirc/parser/events/PrivateNoticeEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public class PrivateNoticeEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public PrivateNoticeEvent(final Parser parser, final Date date, final String message,
+    public PrivateNoticeEvent(final Parser parser, final LocalDateTime date, final String message,
             final String host) {
         super(parser, date);
         this.message = checkNotNull(message);

--- a/common/src/com/dmdirc/parser/events/QuitEvent.java
+++ b/common/src/com/dmdirc/parser/events/QuitEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.interfaces.ClientInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,7 +37,7 @@ public class QuitEvent extends ParserEvent {
     private final ClientInfo client;
     private final String reason;
 
-    public QuitEvent(final Parser parser, final Date date, final ClientInfo client,
+    public QuitEvent(final Parser parser, final LocalDateTime date, final ClientInfo client,
             final String reason) {
         super(parser, date);
         this.client = checkNotNull(client);

--- a/common/src/com/dmdirc/parser/events/ServerErrorEvent.java
+++ b/common/src/com/dmdirc/parser/events/ServerErrorEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -35,7 +35,7 @@ public class ServerErrorEvent extends ParserEvent {
 
     private final String message;
 
-    public ServerErrorEvent(final Parser parser, final Date date, final String message) {
+    public ServerErrorEvent(final Parser parser, final LocalDateTime date, final String message) {
         super(parser, date);
         this.message = checkNotNull(message);
     }

--- a/common/src/com/dmdirc/parser/events/ServerNoticeEvent.java
+++ b/common/src/com/dmdirc/parser/events/ServerNoticeEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public class ServerNoticeEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public ServerNoticeEvent(final Parser parser, final Date date, final String message,
+    public ServerNoticeEvent(final Parser parser, final LocalDateTime date, final String message,
             final String host) {
         super(parser, date);
         this.message = checkNotNull(message);

--- a/common/src/com/dmdirc/parser/events/ServerReadyEvent.java
+++ b/common/src/com/dmdirc/parser/events/ServerReadyEvent.java
@@ -24,14 +24,14 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 /**
  * Called after 001.
  */
 public class ServerReadyEvent extends ParserEvent {
 
-    public ServerReadyEvent(final Parser parser, final Date date) {
+    public ServerReadyEvent(final Parser parser, final LocalDateTime date) {
         super(parser, date);
     }
 }

--- a/common/src/com/dmdirc/parser/events/SocketCloseEvent.java
+++ b/common/src/com/dmdirc/parser/events/SocketCloseEvent.java
@@ -24,14 +24,14 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 /**
  * Called when the socket is closed.
  */
 public class SocketCloseEvent extends ParserEvent {
 
-    public SocketCloseEvent(final Parser parser, final Date date) {
+    public SocketCloseEvent(final Parser parser, final LocalDateTime date) {
         super(parser, date);
     }
 }

--- a/common/src/com/dmdirc/parser/events/UnknownActionEvent.java
+++ b/common/src/com/dmdirc/parser/events/UnknownActionEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,7 +37,7 @@ public class UnknownActionEvent extends ParserEvent {
     private final String target;
     private final String host;
 
-    public UnknownActionEvent(final Parser parser, final Date date, final String message,
+    public UnknownActionEvent(final Parser parser, final LocalDateTime date, final String message,
             final String target, final String host) {
         super(parser, date);
         this.message = checkNotNull(message);

--- a/common/src/com/dmdirc/parser/events/UnknownCTCPEvent.java
+++ b/common/src/com/dmdirc/parser/events/UnknownCTCPEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -38,7 +38,7 @@ public class UnknownCTCPEvent extends ParserEvent {
     private final String target;
     private final String host;
 
-    public UnknownCTCPEvent(final Parser parser, final Date date, final String type,
+    public UnknownCTCPEvent(final Parser parser, final LocalDateTime date, final String type,
             final String message, final String target, final String host) {
         super(parser, date);
         this.type = checkNotNull(type);

--- a/common/src/com/dmdirc/parser/events/UnknownCTCPReplyEvent.java
+++ b/common/src/com/dmdirc/parser/events/UnknownCTCPReplyEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -38,7 +38,7 @@ public class UnknownCTCPReplyEvent extends ParserEvent {
     private final String target;
     private final String host;
 
-    public UnknownCTCPReplyEvent(final Parser parser, final Date date, final String type,
+    public UnknownCTCPReplyEvent(final Parser parser, final LocalDateTime date, final String type,
             final String message, final String target, final String host) {
         super(parser, date);
         this.type = checkNotNull(type);

--- a/common/src/com/dmdirc/parser/events/UnknownMessageEvent.java
+++ b/common/src/com/dmdirc/parser/events/UnknownMessageEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,7 +37,7 @@ public class UnknownMessageEvent extends ParserEvent {
     private final String target;
     private final String host;
 
-    public UnknownMessageEvent(final Parser parser, final Date date,
+    public UnknownMessageEvent(final Parser parser, final LocalDateTime date,
             final String message, final String target, final String host) {
         super(parser, date);
         this.message = checkNotNull(message);

--- a/common/src/com/dmdirc/parser/events/UnknownNoticeEvent.java
+++ b/common/src/com/dmdirc/parser/events/UnknownNoticeEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,7 +37,7 @@ public class UnknownNoticeEvent extends ParserEvent {
     private final String target;
     private final String host;
 
-    public UnknownNoticeEvent(final Parser parser, final Date date,
+    public UnknownNoticeEvent(final Parser parser, final LocalDateTime date,
             final String message, final String target, final String host) {
         super(parser, date);
         this.message = checkNotNull(message);

--- a/common/src/com/dmdirc/parser/events/UnknownServerNoticeEvent.java
+++ b/common/src/com/dmdirc/parser/events/UnknownServerNoticeEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,8 +37,8 @@ public class UnknownServerNoticeEvent extends ParserEvent {
     private final String target;
     private final String host;
 
-    public UnknownServerNoticeEvent(final Parser parser, final Date date, final String message,
-            final String target, final String host) {
+    public UnknownServerNoticeEvent(final Parser parser, final LocalDateTime date,
+            final String message, final String target, final String host) {
         super(parser, date);
         this.message = checkNotNull(message);
         this.target = checkNotNull(target);

--- a/common/src/com/dmdirc/parser/events/UserInfoEvent.java
+++ b/common/src/com/dmdirc/parser/events/UserInfoEvent.java
@@ -25,8 +25,8 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.interfaces.ClientInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.Date;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
@@ -39,7 +39,7 @@ public class UserInfoEvent extends ParserEvent {
     private final ClientInfo client;
     private final Map<UserInfoType, String> info;
 
-    public UserInfoEvent(final Parser parser, final Date date, final ClientInfo client,
+    public UserInfoEvent(final Parser parser, final LocalDateTime date, final ClientInfo client,
             final Map<UserInfoType, String> info) {
         super(parser, date);
         this.client = client;

--- a/common/src/com/dmdirc/parser/events/UserModeChangeEvent.java
+++ b/common/src/com/dmdirc/parser/events/UserModeChangeEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.interfaces.ClientInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -38,8 +38,8 @@ public class UserModeChangeEvent extends ParserEvent {
     private final String host;
     private final String modes;
 
-    public UserModeChangeEvent(final Parser parser, final Date date, final ClientInfo client,
-            final String host, final String modes) {
+    public UserModeChangeEvent(final Parser parser, final LocalDateTime date,
+            final ClientInfo client, final String host, final String modes) {
         super(parser, date);
         this.client = checkNotNull(client);
         this.host = checkNotNull(host);

--- a/common/src/com/dmdirc/parser/events/UserModeDiscoveryEvent.java
+++ b/common/src/com/dmdirc/parser/events/UserModeDiscoveryEvent.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.events;
 import com.dmdirc.parser.interfaces.ClientInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,8 +37,8 @@ public class UserModeDiscoveryEvent extends ParserEvent {
     private final ClientInfo client;
     private final String modes;
 
-    public UserModeDiscoveryEvent(final Parser parser, final Date date, final ClientInfo client,
-            final String modes) {
+    public UserModeDiscoveryEvent(final Parser parser, final LocalDateTime date,
+            final ClientInfo client, final String modes) {
         super(parser, date);
         this.client = checkNotNull(client);
         this.modes = checkNotNull(modes);

--- a/common/src/com/dmdirc/parser/events/WallDesyncEvent.java
+++ b/common/src/com/dmdirc/parser/events/WallDesyncEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public class WallDesyncEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public WallDesyncEvent(final Parser parser, final Date date, final String message,
+    public WallDesyncEvent(final Parser parser, final LocalDateTime date, final String message,
             final String host) {
         super(parser, date);
         this.message = checkNotNull(message);

--- a/common/src/com/dmdirc/parser/events/WallopEvent.java
+++ b/common/src/com/dmdirc/parser/events/WallopEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public class WallopEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public WallopEvent(final Parser parser, final Date date, final String message,
+    public WallopEvent(final Parser parser, final LocalDateTime date, final String message,
             final String host) {
         super(parser, date);
         this.message = checkNotNull(message);

--- a/common/src/com/dmdirc/parser/events/WalluserEvent.java
+++ b/common/src/com/dmdirc/parser/events/WalluserEvent.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public class WalluserEvent extends ParserEvent {
     private final String message;
     private final String host;
 
-    public WalluserEvent(final Parser parser, final Date date, final String message,
+    public WalluserEvent(final Parser parser, final LocalDateTime date, final String message,
             final String host) {
         super(parser, date);
         this.message = checkNotNull(message);

--- a/irc/src/com/dmdirc/parser/irc/IRCParser.java
+++ b/irc/src/com/dmdirc/parser/irc/IRCParser.java
@@ -1090,8 +1090,8 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
 
         if (line.getTags().containsKey("tsirc date")) {
             try {
-                final long ts = Long.parseLong(line.getTags().get("tsirc date"));
-                lineTS = LocalDateTime.ofEpochSecond(ts - tsdiff, 0, ZoneOffset.UTC);
+                final long ts = Long.parseLong(line.getTags().get("tsirc date")) - tsdiff;
+                lineTS = LocalDateTime.ofEpochSecond(ts / 1000L, (int) (ts % 1000L), ZoneOffset.UTC);
             } catch (final NumberFormatException nfe) { /* Do nothing. */ }
         } else if (line.getTags().containsKey("time")) {
             try {

--- a/irc/src/com/dmdirc/parser/irc/ProcessingManager.java
+++ b/irc/src/com/dmdirc/parser/irc/ProcessingManager.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.common.ParserError;
 import com.dmdirc.parser.events.NumericEvent;
 import com.dmdirc.parser.irc.processors.IRCProcessor;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -133,7 +133,7 @@ public class ProcessingManager {
      * @throws ProcessorNotFoundException exception if no processors exists to handle the line
      */
     public void process(final String sParam, final String... token) throws ProcessorNotFoundException {
-        process(new Date(), sParam, token);
+        process(LocalDateTime.now(), sParam, token);
     }
 
     /**
@@ -144,7 +144,8 @@ public class ProcessingManager {
      * @param token IRCTokenised line to process
      * @throws ProcessorNotFoundException exception if no processors exists to handle the line
      */
-    public void process(final Date date, final String sParam, final String... token) throws ProcessorNotFoundException {
+    public void process(final LocalDateTime date, final String sParam, final String... token)
+            throws ProcessorNotFoundException {
         IRCProcessor messageProcessor = null;
         try {
             messageProcessor = getProcessor(sParam);
@@ -178,6 +179,7 @@ public class ProcessingManager {
      * @param token IRC Tokenised line
      */
     protected void callNumeric(final int numeric, final String... token) {
-        parser.getCallbackManager().publish(new NumericEvent(parser, new Date(), numeric, token));
+        parser.getCallbackManager().publish(new NumericEvent(parser, LocalDateTime.now(), numeric,
+                token));
     }
 }

--- a/irc/src/com/dmdirc/parser/irc/SimpleNickInUseHandler.java
+++ b/irc/src/com/dmdirc/parser/irc/SimpleNickInUseHandler.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.events.DebugInfoEvent;
 import com.dmdirc.parser.events.NickInUseEvent;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import net.engio.mbassy.listener.Handler;
 import net.engio.mbassy.listener.Listener;
@@ -73,7 +73,7 @@ public class SimpleNickInUseHandler {
 
     private void callDebugInfo(final Parser parser, final int level, final String data) {
         parser.getCallbackManager().publish(
-                new DebugInfoEvent(parser, new Date(), level, data));
+                new DebugInfoEvent(parser, LocalDateTime.now(), level, data));
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/TimestampedIRCProcessor.java
+++ b/irc/src/com/dmdirc/parser/irc/TimestampedIRCProcessor.java
@@ -24,7 +24,7 @@ package com.dmdirc.parser.irc;
 
 import com.dmdirc.parser.irc.processors.IRCProcessor;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 /**
  * TimestampedIRCProcessor.
@@ -45,7 +45,7 @@ public abstract class TimestampedIRCProcessor extends IRCProcessor {
 
     @Override
     public final void process(final String sParam, final String... token) {
-        process(new Date(), sParam, token);
+        process(LocalDateTime.now(), sParam, token);
     }
 
     /**
@@ -55,7 +55,8 @@ public abstract class TimestampedIRCProcessor extends IRCProcessor {
      * @param sParam Type of line to process ("005", "PRIVMSG" etc)
      * @param token IRCTokenised line to process
      */
-    public abstract void process(final Date date, final String sParam, final String... token);
+    public abstract void process(final LocalDateTime date, final String sParam,
+            final String... token);
 
 
 }

--- a/irc/src/com/dmdirc/parser/irc/WhoisResponseHandler.java
+++ b/irc/src/com/dmdirc/parser/irc/WhoisResponseHandler.java
@@ -28,7 +28,7 @@ import com.dmdirc.parser.events.UserInfoEvent;
 import com.dmdirc.parser.events.UserInfoEvent.UserInfoType;
 import com.dmdirc.parser.interfaces.Parser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -113,7 +113,8 @@ public class WhoisResponseHandler {
     }
 
     private void sendEvent() {
-        manager.publish(new UserInfoEvent(parser, new Date(), parser.getClient(client), info));
+        manager.publish(new UserInfoEvent(parser, LocalDateTime.now(),
+                parser.getClient(client), info));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/Process004005.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/Process004005.java
@@ -30,7 +30,7 @@ import com.dmdirc.parser.irc.IRCEncoding;
 import com.dmdirc.parser.irc.IRCParser;
 import com.dmdirc.parser.irc.ProcessorNotFoundException;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -85,7 +85,8 @@ public class Process004005 extends IRCProcessor {
         final String ircdType = parser.getServerSoftwareType();
 
         getCallbackManager().publish(
-                new NetworkDetectedEvent(parser, new Date(), networkName, ircdVersion, ircdType));
+                new NetworkDetectedEvent(parser, LocalDateTime.now(), networkName, ircdVersion,
+                        ircdType));
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/processors/Process464.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/Process464.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.irc.processors;
 import com.dmdirc.parser.events.PasswordRequiredEvent;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -59,6 +59,6 @@ public class Process464 extends IRCProcessor {
      * Callback to all objects implementing the PasswordRequired Callback.
      */
     protected void callPasswordRequired() {
-        getCallbackManager().publish(new PasswordRequiredEvent(parser, new Date()));
+        getCallbackManager().publish(new PasswordRequiredEvent(parser, LocalDateTime.now()));
     }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessAway.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessAway.java
@@ -26,7 +26,7 @@ import com.dmdirc.parser.events.AwayStateEvent;
 import com.dmdirc.parser.irc.IRCClientInfo;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -93,7 +93,7 @@ public class ProcessAway extends IRCProcessor {
     protected void callAwayState(final AwayState oldState, final AwayState currentState,
             final String reason) {
         getCallbackManager().publish(
-                new AwayStateEvent(parser, new Date(), oldState, currentState, reason));
+                new AwayStateEvent(parser, LocalDateTime.now(), oldState, currentState, reason));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessCap.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessCap.java
@@ -26,9 +26,9 @@ import com.dmdirc.parser.irc.CapabilityState;
 import com.dmdirc.parser.irc.IRCParser;
 import com.dmdirc.parser.irc.TimestampedIRCProcessor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 
 import javax.inject.Inject;
 
@@ -81,7 +81,7 @@ public class ProcessCap extends TimestampedIRCProcessor {
      * @param token IRCTokenised line to process
      */
     @Override
-    public void process(final Date date, final String sParam, final String... token) {
+    public void process(final LocalDateTime date, final String sParam, final String... token) {
         // We will only automatically handle the first ever pre-001 CAP LS
         // response.
         // After that, the user may be sending stuff themselves so we do

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessInvite.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessInvite.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.irc.processors;
 import com.dmdirc.parser.events.InviteEvent;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -65,7 +65,8 @@ public class ProcessInvite extends IRCProcessor {
      * @param channel The name of the channel we were invited to
      */
     protected void callInvite(final String userHost, final String channel) {
-        getCallbackManager().publish(new InviteEvent(parser, new Date(), userHost, channel));
+        getCallbackManager().publish(new InviteEvent(
+                parser, LocalDateTime.now(), userHost, channel));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessJoin.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessJoin.java
@@ -37,8 +37,8 @@ import com.dmdirc.parser.irc.ModeManager;
 import com.dmdirc.parser.irc.PrefixModeManager;
 import com.dmdirc.parser.irc.ProcessorNotFoundException;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.Date;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -185,7 +185,7 @@ public class ProcessJoin extends IRCProcessor {
     protected void callChannelJoin(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient) {
         getCallbackManager().publish(
-                new ChannelJoinEvent(parser, new Date(), cChannel, cChannelClient));
+                new ChannelJoinEvent(parser, LocalDateTime.now(), cChannel, cChannelClient));
     }
 
     /**
@@ -194,7 +194,8 @@ public class ProcessJoin extends IRCProcessor {
      * @param cChannel Channel Object
      */
     protected void callChannelSelfJoin(final ChannelInfo cChannel) {
-        getCallbackManager().publish(new ChannelSelfJoinEvent(parser, new Date(), cChannel));
+        getCallbackManager().publish(new ChannelSelfJoinEvent(
+                parser, LocalDateTime.now(), cChannel));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessKick.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessKick.java
@@ -31,8 +31,8 @@ import com.dmdirc.parser.irc.IRCChannelInfo;
 import com.dmdirc.parser.irc.IRCClientInfo;
 import com.dmdirc.parser.irc.IRCParser;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.Date;
 
 import javax.inject.Inject;
 
@@ -122,8 +122,8 @@ public class ProcessKick extends IRCProcessor {
             final ChannelClientInfo cKickedClient, final ChannelClientInfo cKickedByClient,
             final String sReason, final String sKickedByHost) {
         getCallbackManager().publish(
-                new ChannelKickEvent(parser, new Date(), cChannel, cKickedClient, cKickedByClient,
-                        sReason, sKickedByHost));
+                new ChannelKickEvent(parser, LocalDateTime.now(), cChannel, cKickedClient,
+                        cKickedByClient, sReason, sKickedByHost));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessList.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessList.java
@@ -27,7 +27,7 @@ import com.dmdirc.parser.events.GroupListEntryEvent;
 import com.dmdirc.parser.events.GroupListStartEvent;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -59,14 +59,14 @@ public class ProcessList extends IRCProcessor {
         // :port80b.se.quakenet.org 323 MD87 :End of /LIST
         switch (sParam) {
             case "321":
-                getCallbackManager().publish(new GroupListStartEvent(parser, new Date()));
+                getCallbackManager().publish(new GroupListStartEvent(parser, LocalDateTime.now()));
                 break;
             case "322":
-                getCallbackManager().publish(new GroupListEntryEvent(parser, new Date(), token[3],
-                        Integer.parseInt(token[4]), token[5]));
+                getCallbackManager().publish(new GroupListEntryEvent(parser, LocalDateTime.now(),
+                        token[3], Integer.parseInt(token[4]), token[5]));
                 break;
             case "323":
-                getCallbackManager().publish(new GroupListEndEvent(parser, new Date()));
+                getCallbackManager().publish(new GroupListEndEvent(parser, LocalDateTime.now()));
                 break;
         }
     }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessListModes.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessListModes.java
@@ -30,9 +30,9 @@ import com.dmdirc.parser.irc.IRCParser;
 import com.dmdirc.parser.irc.ServerType;
 import com.dmdirc.parser.irc.ServerTypeGroup;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Queue;
 
 import javax.inject.Inject;
@@ -286,6 +286,7 @@ public class ProcessListModes extends IRCProcessor {
      * @param mode the mode that we got list modes for.
      */
     protected void callChannelGotListModes(final ChannelInfo cChannel, final char mode) {
-        getCallbackManager().publish(new ChannelListModeEvent(parser, new Date(), cChannel, mode));
+        getCallbackManager().publish(new ChannelListModeEvent(parser, LocalDateTime.now(), cChannel,
+                mode));
     }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessMOTD.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessMOTD.java
@@ -27,7 +27,7 @@ import com.dmdirc.parser.events.MOTDLineEvent;
 import com.dmdirc.parser.events.MOTDStartEvent;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -74,7 +74,7 @@ public class ProcessMOTD extends IRCProcessor {
      * @param data The contents of the line (incase of language changes or so)
      */
     protected void callMOTDEnd(final boolean noMOTD, final String data) {
-        getCallbackManager().publish(new MOTDEndEvent(parser, new Date(), noMOTD, data));
+        getCallbackManager().publish(new MOTDEndEvent(parser, LocalDateTime.now(), noMOTD, data));
     }
 
     /**
@@ -83,7 +83,7 @@ public class ProcessMOTD extends IRCProcessor {
      * @param data Incomming Line.
      */
     protected void callMOTDLine(final String data) {
-        getCallbackManager().publish(new MOTDLineEvent(parser, new Date(), data));
+        getCallbackManager().publish(new MOTDLineEvent(parser, LocalDateTime.now(), data));
     }
 
     /**
@@ -92,7 +92,7 @@ public class ProcessMOTD extends IRCProcessor {
      * @param data Incomming Line.
      */
     protected void callMOTDStart(final String data) {
-        getCallbackManager().publish(new MOTDStartEvent(parser, new Date(), data));
+        getCallbackManager().publish(new MOTDStartEvent(parser, LocalDateTime.now(), data));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessMessage.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessMessage.java
@@ -52,6 +52,7 @@ import com.dmdirc.parser.irc.PrefixModeManager;
 import com.dmdirc.parser.irc.ProcessorNotFoundException;
 import com.dmdirc.parser.irc.TimestampedIRCProcessor;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.regex.PatternSyntaxException;
 
@@ -94,7 +95,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param token IRCTokenised line to process
      */
     @Override
-    public void process(final Date date, final String sParam, final String... token) {
+    public void process(final LocalDateTime date, final String sParam, final String... token) {
         // Ignore people!
         String sMessage;
         if (token[0].charAt(0) == ':') {
@@ -296,7 +297,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage action contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callChannelAction(final Date date, final ChannelInfo cChannel,
+    protected void callChannelAction(final LocalDateTime date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sMessage, final String sHost) {
         getCallbackManager().publish(
                 new ChannelActionEvent(parser, date, cChannel, cChannelClient, sMessage, sHost));
@@ -312,7 +313,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage Additional contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callChannelCTCP(final Date date, final ChannelInfo cChannel,
+    protected void callChannelCTCP(final LocalDateTime date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sType, final String sMessage,
             final String sHost) {
         getCallbackManager().publish(
@@ -330,7 +331,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage Reply Contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callChannelCTCPReply(final Date date, final ChannelInfo cChannel,
+    protected void callChannelCTCPReply(final LocalDateTime date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sType, final String sMessage,
             final String sHost) {
         getCallbackManager().publish(
@@ -347,7 +348,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage Message contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callChannelMessage(final Date date, final ChannelInfo cChannel,
+    protected void callChannelMessage(final LocalDateTime date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sMessage, final String sHost) {
         getCallbackManager().publish(
                 new ChannelMessageEvent(parser, date, cChannel, cChannelClient, sMessage, sHost));
@@ -362,7 +363,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage notice contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callChannelNotice(final Date date, final ChannelInfo cChannel,
+    protected void callChannelNotice(final LocalDateTime date, final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sMessage, final String sHost) {
         getCallbackManager().publish(
                 new ChannelNoticeEvent(parser, date, cChannel, cChannelClient, sMessage, sHost));
@@ -378,7 +379,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage notice contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callChannelModeNotice(final Date date, final char prefix,
+    protected void callChannelModeNotice(final LocalDateTime date, final char prefix,
             final ChannelInfo cChannel, final ChannelClientInfo cChannelClient,
             final String sMessage, final String sHost) {
         getCallbackManager().publish(
@@ -396,7 +397,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage message contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callChannelModeMessage(final Date date, final char prefix,
+    protected void callChannelModeMessage(final LocalDateTime date, final char prefix,
             final ChannelInfo cChannel, final ChannelClientInfo cChannelClient,
             final String sMessage, final String sHost) {
         getCallbackManager().publish(
@@ -411,7 +412,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage action contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callPrivateAction(final Date date, final String sMessage, final String sHost) {
+    protected void callPrivateAction(final LocalDateTime date, final String sMessage,
+            final String sHost) {
         getCallbackManager().publish(new PrivateActionEvent(parser, date, sMessage, sHost));
     }
 
@@ -423,8 +425,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage Additional contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callPrivateCTCP(final Date date, final String sType, final String sMessage,
-            final String sHost) {
+    protected void callPrivateCTCP(final LocalDateTime date, final String sType,
+            final String sMessage, final String sHost) {
         getCallbackManager().publish(new PrivateCTCPEvent(parser, date, sType, sMessage, sHost));
     }
 
@@ -436,8 +438,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage Reply Contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callPrivateCTCPReply(final Date date, final String sType, final String sMessage,
-            final String sHost) {
+    protected void callPrivateCTCPReply(final LocalDateTime date, final String sType,
+            final String sMessage, final String sHost) {
         getCallbackManager().publish(
                 new PrivateCTCPReplyEvent(parser, date, sType, sMessage, sHost));
     }
@@ -449,7 +451,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage Message contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callPrivateMessage(final Date date, final String sMessage, final String sHost) {
+    protected void callPrivateMessage(final LocalDateTime date, final String sMessage,
+            final String sHost) {
         getCallbackManager().publish(new PrivateMessageEvent(parser, date, sMessage, sHost));
     }
 
@@ -460,7 +463,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage Notice contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callPrivateNotice(final Date date, final String sMessage, final String sHost) {
+    protected void callPrivateNotice(final LocalDateTime date, final String sMessage,
+            final String sHost) {
         getCallbackManager().publish(new PrivateNoticeEvent(parser, date, sMessage, sHost));
     }
 
@@ -471,7 +475,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sMessage Notice contents
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callServerNotice(final Date date, final String sMessage, final String sHost) {
+    protected void callServerNotice(final LocalDateTime date, final String sMessage,
+            final String sHost) {
         getCallbackManager().publish(new ServerNoticeEvent(parser, date, sMessage, sHost));
     }
 
@@ -483,8 +488,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sTarget Actual target of action
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callUnknownAction(final Date date, final String sMessage, final String sTarget,
-            final String sHost) {
+    protected void callUnknownAction(final LocalDateTime date, final String sMessage,
+            final String sTarget, final String sHost) {
         getCallbackManager().publish(new UnknownActionEvent(parser, date, sMessage, sTarget, sHost));
     }
 
@@ -497,8 +502,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sTarget Actual Target of CTCP
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callUnknownCTCP(final Date date, final String sType, final String sMessage,
-            final String sTarget, final String sHost) {
+    protected void callUnknownCTCP(final LocalDateTime date, final String sType,
+            final String sMessage, final String sTarget, final String sHost) {
         getCallbackManager().publish(
                 new UnknownCTCPEvent(parser, date, sType, sMessage, sTarget, sHost));
     }
@@ -512,8 +517,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sTarget Actual Target of CTCPReply
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callUnknownCTCPReply(final Date date, final String sType, final String sMessage,
-            final String sTarget, final String sHost) {
+    protected void callUnknownCTCPReply(final LocalDateTime date, final String sType,
+            final String sMessage, final String sTarget, final String sHost) {
         getCallbackManager().publish(
                 new UnknownCTCPReplyEvent(parser, date, sType, sMessage, sTarget, sHost));
     }
@@ -526,8 +531,8 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sTarget Actual target of message
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callUnknownMessage(final Date date, final String sMessage, final String sTarget,
-            final String sHost) {
+    protected void callUnknownMessage(final LocalDateTime date, final String sMessage,
+            final String sTarget, final String sHost) {
         getCallbackManager().publish(
                 new UnknownMessageEvent(parser, date, sMessage, sTarget, sHost));
     }
@@ -540,9 +545,10 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sTarget Actual target of notice
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callUnknownNotice(final Date date, final String sMessage, final String sTarget,
-            final String sHost) {
-        getCallbackManager().publish(new UnknownNoticeEvent(parser, date, sMessage, sTarget, sHost));
+    protected void callUnknownNotice(final LocalDateTime date, final String sMessage,
+            final String sTarget, final String sHost) {
+        getCallbackManager().publish(new UnknownNoticeEvent(parser, date, sMessage, sTarget,
+                sHost));
     }
 
     /**
@@ -553,7 +559,7 @@ public class ProcessMessage extends TimestampedIRCProcessor {
      * @param sTarget Actual target of notice
      * @param sHost Hostname of sender (or servername)
      */
-    protected void callUnknownServerNotice(final Date date, final String sMessage,
+    protected void callUnknownServerNotice(final LocalDateTime date, final String sMessage,
             final String sTarget, final String sHost) {
         getCallbackManager().publish(
                 new UnknownServerNoticeEvent(parser, date, sMessage, sTarget, sHost));

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessMode.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessMode.java
@@ -40,8 +40,8 @@ import com.dmdirc.parser.irc.IRCParser;
 import com.dmdirc.parser.irc.ModeManager;
 import com.dmdirc.parser.irc.PrefixModeManager;
 
+import java.time.LocalDateTime;
 import java.util.Calendar;
-import java.util.Date;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -232,7 +232,8 @@ public class ProcessMode extends IRCProcessor {
                         callDebugInfo(IRCParser.DEBUG_INFO, "List Mode: %c [%s] {Positive: %b}", cMode, sModeParam, bPositive);
                         if (!"324".equals(sParam)) {
                             getCallbackManager().publish(
-                                    new ChannelSingleModeChangeEvent(parser, new Date(), iChannel,
+                                    new ChannelSingleModeChangeEvent(
+                                            parser, LocalDateTime.now(), iChannel,
                                             setterCCI, token[0], cPositive + cMode + " " +
                                             sModeParam));
                         }
@@ -246,7 +247,8 @@ public class ProcessMode extends IRCProcessor {
                             iChannel.setModeParam(cMode, sModeParam);
                             if (!"324".equals(sParam)) {
                                 getCallbackManager().publish(
-                                        new ChannelSingleModeChangeEvent(parser, new Date(),
+                                        new ChannelSingleModeChangeEvent(
+                                                parser, LocalDateTime.now(),
                                                 iChannel, setterCCI, token[0],
                                                 cPositive + cMode + " " +
                                                         sModeParam));
@@ -263,7 +265,8 @@ public class ProcessMode extends IRCProcessor {
                             iChannel.setModeParam(cMode, "");
                             if (!"324".equals(sParam)) {
                                 getCallbackManager().publish(
-                                        new ChannelSingleModeChangeEvent(parser, new Date(),
+                                        new ChannelSingleModeChangeEvent(
+                                                parser, LocalDateTime.now(),
                                                 iChannel, setterCCI, token[0],
                                                 trim(cPositive + cMode + " " + sModeParam)));
                             }
@@ -284,8 +287,9 @@ public class ProcessMode extends IRCProcessor {
         } else {
             callChannelModeChanged(iChannel, setterCCI, token[0], sFullModeStr.toString().trim());
             getCallbackManager().publish(
-                    new ChannelNonUserModeChangeEvent(parser, new Date(), iChannel, setterCCI,
-                            token[0], trim(sNonUserModeStr.toString() + sNonUserModeStrParams)));
+                    new ChannelNonUserModeChangeEvent(parser, LocalDateTime.now(), iChannel,
+                            setterCCI, token[0],
+                            trim(sNonUserModeStr.toString() + sNonUserModeStrParams)));
         }
     }
 
@@ -353,8 +357,8 @@ public class ProcessMode extends IRCProcessor {
     protected void callChannelModeChanged(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sHost, final String sModes) {
         getCallbackManager().publish(
-                new ChannelModeChangeEvent(parser, new Date(), cChannel, cChannelClient, sHost,
-                        sModes));
+                new ChannelModeChangeEvent(parser, LocalDateTime.now(), cChannel, cChannelClient,
+                        sHost, sModes));
     }
 
     /**
@@ -370,8 +374,8 @@ public class ProcessMode extends IRCProcessor {
             final ChannelClientInfo cChangedClient, final ChannelClientInfo cSetByClient,
             final String sHost, final String sMode) {
         getCallbackManager().publish(
-                new ChannelUserModeChangeEvent(parser, new Date(), cChannel, cChangedClient,
-                        cSetByClient, sHost, sMode));
+                new ChannelUserModeChangeEvent(parser, LocalDateTime.now(), cChannel,
+                        cChangedClient, cSetByClient, sHost, sMode));
     }
 
     /**
@@ -384,7 +388,7 @@ public class ProcessMode extends IRCProcessor {
     protected void callUserModeChanged(final ClientInfo cClient, final String sSetby,
             final String sModes) {
         getCallbackManager().publish(
-                new UserModeChangeEvent(parser, new Date(), cClient, sSetby, sModes));
+                new UserModeChangeEvent(parser, LocalDateTime.now(), cClient, sSetby, sModes));
     }
 
     /**
@@ -395,7 +399,7 @@ public class ProcessMode extends IRCProcessor {
      */
     protected void callUserModeDiscovered(final ClientInfo cClient, final String sModes) {
         getCallbackManager().publish(
-                new UserModeDiscoveryEvent(parser, new Date(), cClient, sModes));
+                new UserModeDiscoveryEvent(parser, LocalDateTime.now(), cClient, sModes));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNames.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNames.java
@@ -32,7 +32,7 @@ import com.dmdirc.parser.irc.IRCParser;
 import com.dmdirc.parser.irc.ModeManager;
 import com.dmdirc.parser.irc.PrefixModeManager;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -149,7 +149,7 @@ public class ProcessNames extends IRCProcessor {
     protected void callChannelTopic(final ChannelInfo cChannel, final boolean bIsJoinTopic) {
         ((IRCChannelInfo) cChannel).setHadTopic();
         getCallbackManager().publish(
-                new ChannelTopicEvent(parser, new Date(), cChannel, bIsJoinTopic));
+                new ChannelTopicEvent(parser, LocalDateTime.now(), cChannel, bIsJoinTopic));
     }
 
     /**
@@ -158,7 +158,7 @@ public class ProcessNames extends IRCProcessor {
      * @param cChannel Channel which the names reply is for
      */
     protected void callChannelGotNames(final ChannelInfo cChannel) {
-        getCallbackManager().publish(new ChannelNamesEvent(parser, new Date(), cChannel));
+        getCallbackManager().publish(new ChannelNamesEvent(parser, LocalDateTime.now(), cChannel));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNick.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNick.java
@@ -33,7 +33,7 @@ import com.dmdirc.parser.irc.IRCChannelInfo;
 import com.dmdirc.parser.irc.IRCClientInfo;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -110,7 +110,8 @@ public class ProcessNick extends IRCProcessor {
     protected void callChannelNickChanged(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sOldNick) {
         getCallbackManager().publish(
-                new ChannelNickChangeEvent(parser, new Date(), cChannel, cChannelClient, sOldNick));
+                new ChannelNickChangeEvent(parser, LocalDateTime.now(), cChannel, cChannelClient,
+                        sOldNick));
     }
 
     /**
@@ -120,7 +121,8 @@ public class ProcessNick extends IRCProcessor {
      * @param sOldNick Nickname before change
      */
     protected void callNickChanged(final ClientInfo cClient, final String sOldNick) {
-        getCallbackManager().publish(new NickChangeEvent(parser, new Date(), cClient, sOldNick));
+        getCallbackManager().publish(new NickChangeEvent(parser, LocalDateTime.now(), cClient,
+                sOldNick));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNickInUse.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNickInUse.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.irc.processors;
 import com.dmdirc.parser.events.NickInUseEvent;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -73,7 +73,7 @@ public class ProcessNickInUse extends IRCProcessor {
      * @param nickname Nickname that was wanted.
      */
     protected void callNickInUse(final String nickname) {
-        getCallbackManager().publish(new NickInUseEvent(parser, new Date(), nickname));
+        getCallbackManager().publish(new NickInUseEvent(parser, LocalDateTime.now(), nickname));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessNoticeAuth.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessNoticeAuth.java
@@ -25,7 +25,7 @@ package com.dmdirc.parser.irc.processors;
 import com.dmdirc.parser.events.AuthNoticeEvent;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -61,7 +61,7 @@ public class ProcessNoticeAuth extends IRCProcessor {
      * @param data Incomming Line.
      */
     protected void callNoticeAuth(final String data) {
-        getCallbackManager().publish(new AuthNoticeEvent(parser, new Date(), data));
+        getCallbackManager().publish(new AuthNoticeEvent(parser, LocalDateTime.now(), data));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessPart.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessPart.java
@@ -31,7 +31,7 @@ import com.dmdirc.parser.irc.IRCChannelInfo;
 import com.dmdirc.parser.irc.IRCClientInfo;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -115,7 +115,8 @@ public class ProcessPart extends IRCProcessor {
     protected void callChannelPart(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sReason) {
         getCallbackManager().publish(
-                new ChannelPartEvent(parser, new Date(), cChannel, cChannelClient, sReason));
+                new ChannelPartEvent(parser, LocalDateTime.now(), cChannel, cChannelClient,
+                        sReason));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessQuit.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessQuit.java
@@ -32,8 +32,8 @@ import com.dmdirc.parser.irc.IRCChannelInfo;
 import com.dmdirc.parser.irc.IRCClientInfo;
 import com.dmdirc.parser.irc.IRCParser;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 
 import javax.inject.Inject;
 
@@ -122,7 +122,8 @@ public class ProcessQuit extends IRCProcessor {
     protected void callChannelQuit(final ChannelInfo cChannel,
             final ChannelClientInfo cChannelClient, final String sReason) {
         getCallbackManager().publish(
-                new ChannelQuitEvent(parser, new Date(), cChannel, cChannelClient, sReason));
+                new ChannelQuitEvent(parser, LocalDateTime.now(), cChannel, cChannelClient,
+                        sReason));
     }
 
     /**
@@ -132,7 +133,7 @@ public class ProcessQuit extends IRCProcessor {
      * @param sReason Reason for quitting (may be "")
      */
     protected void callQuit(final ClientInfo cClient, final String sReason) {
-        getCallbackManager().publish(new QuitEvent(parser, new Date(), cClient, sReason));
+        getCallbackManager().publish(new QuitEvent(parser, LocalDateTime.now(), cClient, sReason));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessTopic.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessTopic.java
@@ -28,7 +28,7 @@ import com.dmdirc.parser.irc.IRCChannelInfo;
 import com.dmdirc.parser.irc.IRCClientInfo;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -105,7 +105,7 @@ public class ProcessTopic extends IRCProcessor {
     protected void callChannelTopic(final ChannelInfo cChannel, final boolean bIsJoinTopic) {
         ((IRCChannelInfo) cChannel).setHadTopic();
         getCallbackManager().publish(
-                new ChannelTopicEvent(parser, new Date(), cChannel, bIsJoinTopic));
+                new ChannelTopicEvent(parser, LocalDateTime.now(), cChannel, bIsJoinTopic));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessWallops.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessWallops.java
@@ -27,7 +27,7 @@ import com.dmdirc.parser.events.WallopEvent;
 import com.dmdirc.parser.events.WalluserEvent;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -84,7 +84,7 @@ public class ProcessWallops extends IRCProcessor {
      * @param host Host of the user who sent the wallop
      */
     protected void callWallop(final String message, final String host) {
-        getCallbackManager().publish(new WallopEvent(parser, new Date(), message, host));
+        getCallbackManager().publish(new WallopEvent(parser, LocalDateTime.now(), message, host));
     }
 
     /**
@@ -94,7 +94,7 @@ public class ProcessWallops extends IRCProcessor {
      * @param host Host of the user who sent the walluser
      */
     protected void callWalluser(final String message, final String host) {
-        getCallbackManager().publish(new WalluserEvent(parser, new Date(), message, host));
+        getCallbackManager().publish(new WalluserEvent(parser, LocalDateTime.now(), message, host));
     }
 
     /**
@@ -104,7 +104,8 @@ public class ProcessWallops extends IRCProcessor {
      * @param host Host of the user who sent the WallDesync
      */
     protected void callWallDesync(final String message, final String host) {
-        getCallbackManager().publish(new WallDesyncEvent(parser, new Date(), message, host));
+        getCallbackManager().publish(new WallDesyncEvent(
+                parser, LocalDateTime.now(), message, host));
     }
 
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessWho.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessWho.java
@@ -32,7 +32,7 @@ import com.dmdirc.parser.interfaces.ClientInfo;
 import com.dmdirc.parser.irc.IRCClientInfo;
 import com.dmdirc.parser.irc.IRCParser;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.inject.Inject;
 
@@ -109,7 +109,7 @@ public class ProcessWho extends IRCProcessor {
     protected void callAwayState(final AwayState oldState, final AwayState currentState,
             final String reason) {
         getCallbackManager().publish(
-                new AwayStateEvent(parser, new Date(), oldState, currentState, reason));
+                new AwayStateEvent(parser, LocalDateTime.now(), oldState, currentState, reason));
     }
 
     /**
@@ -122,7 +122,7 @@ public class ProcessWho extends IRCProcessor {
     protected void callAwayStateOther(final ClientInfo client, final AwayState oldState,
             final AwayState state) {
         getCallbackManager().publish(
-                new OtherAwayStateEvent(parser, new Date(), client, oldState, state));
+                new OtherAwayStateEvent(parser, LocalDateTime.now(), client, oldState, state));
     }
 
     /**
@@ -136,8 +136,8 @@ public class ProcessWho extends IRCProcessor {
     protected void callChannelAwayStateOther(final ChannelInfo channel,
             final ChannelClientInfo channelClient, final AwayState oldState, final AwayState state) {
         getCallbackManager().publish(
-                new ChannelOtherAwayStateEvent(parser, new Date(), channel, channelClient, oldState,
-                        state));
+                new ChannelOtherAwayStateEvent(parser, LocalDateTime.now(), channel, channelClient,
+                        oldState, state));
     }
 
 }

--- a/xmpp/src/com/dmdirc/parser/xmpp/XmppFakeChannel.java
+++ b/xmpp/src/com/dmdirc/parser/xmpp/XmppFakeChannel.java
@@ -29,8 +29,8 @@ import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ClientInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.Date;
 
 /**
  * A 'fake' local channel used to display buddy lists.
@@ -135,7 +135,7 @@ public class XmppFakeChannel extends BaseChannelInfo {
 
         // TODO: Delete old contacts, don't needlessly create new objects
         getParser().getCallbackManager().publish(
-                new ChannelNamesEvent(getParser(), new Date(), this));
+                new ChannelNamesEvent(getParser(), LocalDateTime.now(), this));
     }
 
 }

--- a/xmpp/src/com/dmdirc/parser/xmpp/XmppParser.java
+++ b/xmpp/src/com/dmdirc/parser/xmpp/XmppParser.java
@@ -48,9 +48,9 @@ import com.dmdirc.parser.interfaces.LocalClientInfo;
 import com.dmdirc.parser.interfaces.StringConverter;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -241,7 +241,7 @@ public class XmppParser extends BaseSocketAwareParser {
         newArgs[2] = getLocalClient().getNickname();
         System.arraycopy(args, 0, newArgs, 3, args.length);
 
-        getCallbackManager().publish(new NumericEvent(this, new Date(), numeric, newArgs));
+        getCallbackManager().publish(new NumericEvent(this, LocalDateTime.now(), numeric, newArgs));
     }
 
     @Override
@@ -407,7 +407,7 @@ public class XmppParser extends BaseSocketAwareParser {
     @Override
     public void run() {
         if (getURI().getUserInfo() == null || !getURI().getUserInfo().contains(":")) {
-            getCallbackManager().publish(new ConnectErrorEvent(this, new Date(),
+            getCallbackManager().publish(new ConnectErrorEvent(this, LocalDateTime.now(),
                     new ParserError(ParserError.ERROR_USER,
                             "User name and password must be specified in URI", "")));
             return;
@@ -439,7 +439,7 @@ public class XmppParser extends BaseSocketAwareParser {
             try {
                 connection.login(userInfoParts[0], userInfoParts[1], "DMDirc.");
             } catch (XMPPException ex) {
-                getCallbackManager().publish(new ConnectErrorEvent(this, new Date(),
+                getCallbackManager().publish(new ConnectErrorEvent(this, LocalDateTime.now(),
                         new ParserError(ParserError.ERROR_USER, ex.getMessage(), "")));
                 return;
             }
@@ -452,7 +452,7 @@ public class XmppParser extends BaseSocketAwareParser {
 
             setServerName(connection.getServiceName());
 
-            getCallbackManager().publish(new ServerReadyEvent(this, new Date()));
+            getCallbackManager().publish(new ServerReadyEvent(this, LocalDateTime.now()));
 
             for (RosterEntry contact : connection.getRoster().getEntries()) {
                 getClient(contact.getUser()).setRosterEntry(contact);
@@ -465,8 +465,8 @@ public class XmppParser extends BaseSocketAwareParser {
 
                 contacts.values().stream().filter(XmppClientInfo::isAway).forEach(client ->
                         getCallbackManager().publish(
-                                new OtherAwayStateEvent(this, new Date(), client, AwayState.UNKNOWN,
-                                        AwayState.AWAY)));
+                                new OtherAwayStateEvent(this, LocalDateTime.now(), client,
+                                        AwayState.UNKNOWN, AwayState.AWAY)));
             }
         } catch (XMPPException ex) {
             LOG.debug("Go an XMPP exception", ex);
@@ -484,7 +484,7 @@ public class XmppParser extends BaseSocketAwareParser {
                 error.setException(ex);
             }
 
-            getCallbackManager().publish(new ConnectErrorEvent(this, new Date(), error));
+            getCallbackManager().publish(new ConnectErrorEvent(this, LocalDateTime.now(), error));
         }
     }
 
@@ -499,7 +499,7 @@ public class XmppParser extends BaseSocketAwareParser {
 
         if (useFakeChannel) {
             getCallbackManager().publish(new OtherAwayStateEvent(
-                    this, new Date(), client, isBack ? AwayState.AWAY : AwayState.HERE,
+                    this, LocalDateTime.now(), client, isBack ? AwayState.AWAY : AwayState.HERE,
                     isBack ? AwayState.HERE : AwayState.AWAY));
         }
     }
@@ -514,7 +514,8 @@ public class XmppParser extends BaseSocketAwareParser {
                 priority, Presence.Mode.away));
 
         getCallbackManager().publish(
-                new AwayStateEvent(this, new Date(), AwayState.HERE, AwayState.AWAY, reason));
+                new AwayStateEvent(this, LocalDateTime.now(), AwayState.HERE, AwayState.AWAY,
+                        reason));
     }
 
     /**
@@ -525,7 +526,8 @@ public class XmppParser extends BaseSocketAwareParser {
                 priority, Presence.Mode.available));
 
         getCallbackManager().publish(
-                new AwayStateEvent(this, new Date(), AwayState.AWAY, AwayState.HERE, null));
+                new AwayStateEvent(this, LocalDateTime.now(), AwayState.AWAY, AwayState.HERE,
+                        null));
     }
 
     @Override
@@ -568,13 +570,15 @@ public class XmppParser extends BaseSocketAwareParser {
 
         @Override
         public void connectionClosed() {
-            getCallbackManager().publish(new SocketCloseEvent(XmppParser.this, new Date()));
+            getCallbackManager().publish(new SocketCloseEvent(XmppParser.this,
+                    LocalDateTime.now()));
         }
 
         @Override
         public void connectionClosedOnError(final Exception excptn) {
             // TODO: Handle exception
-            getCallbackManager().publish(new SocketCloseEvent(XmppParser.this, new Date()));
+            getCallbackManager().publish(new SocketCloseEvent(XmppParser.this,
+                    LocalDateTime.now()));
         }
 
         @Override
@@ -636,7 +640,8 @@ public class XmppParser extends BaseSocketAwareParser {
         @Override
         public void processMessage(final Chat chat, final Message msg) {
             if (msg.getType() == Message.Type.error) {
-                getCallbackManager().publish(new NumericEvent(XmppParser.this, new Date(), 404,
+                getCallbackManager().publish(new NumericEvent(XmppParser.this, LocalDateTime.now(),
+                        404,
                         new String[]{":xmpp", "404", getLocalClient().getNickname(), msg.getFrom(),
                                 "Cannot send message: " + msg.getError().toString()}));
                 return;
@@ -644,11 +649,13 @@ public class XmppParser extends BaseSocketAwareParser {
 
             if (msg.getBody() != null) {
                 if (msg.getBody().startsWith("/me ")) {
-                    getCallbackManager().publish(new PrivateActionEvent(XmppParser.this, new Date(),
+                    getCallbackManager().publish(new PrivateActionEvent(XmppParser.this,
+                            LocalDateTime.now(),
                             msg.getBody().substring(4), msg.getFrom()));
                 } else {
                     getCallbackManager().publish(
-                            new PrivateMessageEvent(XmppParser.this, new Date(), msg.getBody(),
+                            new PrivateMessageEvent(XmppParser.this,
+                                    LocalDateTime.now(), msg.getBody(),
                                     msg.getFrom()));
                 }
             }
@@ -674,7 +681,7 @@ public class XmppParser extends BaseSocketAwareParser {
             }
 
             getCallbackManager().publish(
-                    new CompositionStateChangeEvent(XmppParser.this, new Date(), state,
+                    new CompositionStateChangeEvent(XmppParser.this, LocalDateTime.now(), state,
                             chat.getParticipant()));
         }
 
@@ -692,10 +699,10 @@ public class XmppParser extends BaseSocketAwareParser {
         public void processPacket(final Packet packet) {
             if (dataOut) {
                 getCallbackManager().publish(
-                        new DataOutEvent(XmppParser.this, new Date(), packet.toXML()));
+                        new DataOutEvent(XmppParser.this, LocalDateTime.now(), packet.toXML()));
             } else {
                 getCallbackManager().publish(
-                        new DataInEvent(XmppParser.this, new Date(), packet.toXML()));
+                        new DataInEvent(XmppParser.this, LocalDateTime.now(), packet.toXML()));
             }
         }
 


### PR DESCRIPTION
Java 8 introduces a sane API for dates; to store datettimes
we should now be using LocalDateTime.