### PR TITLE
Try to keep track of channel keys (Close Issue #108)

### DIFF
--- a/common/src/com/dmdirc/parser/common/BaseChannelInfo.java
+++ b/common/src/com/dmdirc/parser/common/BaseChannelInfo.java
@@ -69,6 +69,11 @@ public abstract class BaseChannelInfo implements ChannelInfo {
     }
 
     @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
     public void sendMessage(final String message) {
         parser.sendMessage(name, message);
     }

--- a/common/src/com/dmdirc/parser/events/ChannelPasswordChangedEvent.java
+++ b/common/src/com/dmdirc/parser/events/ChannelPasswordChangedEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2006-2014 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.parser.events;
+
+import com.dmdirc.parser.interfaces.ChannelInfo;
+import com.dmdirc.parser.interfaces.Parser;
+
+import java.time.LocalDateTime;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Called when a channel password changes.
+ */
+public class ChannelPasswordChangedEvent extends ParserEvent {
+
+    private final ChannelInfo channel;
+
+    public ChannelPasswordChangedEvent(final Parser parser, final LocalDateTime date,
+                                  final ChannelInfo channel) {
+        super(parser, date);
+        this.channel = checkNotNull(channel);
+    }
+
+    public ChannelInfo getChannel() {
+        return channel;
+    }
+}

--- a/common/src/com/dmdirc/parser/interfaces/ChannelInfo.java
+++ b/common/src/com/dmdirc/parser/interfaces/ChannelInfo.java
@@ -43,6 +43,13 @@ public interface ChannelInfo {
     String getName();
 
     /**
+     * Returns the password for this channel.
+     *
+     * @return The password for this channel
+     */
+    String getPassword();
+
+    /**
      * Changes the topic of this channel.
      *
      * @param topic This channel's new topic

--- a/irc/src/com/dmdirc/parser/irc/IRCChannelInfo.java
+++ b/irc/src/com/dmdirc/parser/irc/IRCChannelInfo.java
@@ -30,6 +30,7 @@ import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.ClientInfo;
 import com.dmdirc.parser.interfaces.Parser;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/irc/src/com/dmdirc/parser/irc/IRCChannelInfo.java
+++ b/irc/src/com/dmdirc/parser/irc/IRCChannelInfo.java
@@ -24,6 +24,7 @@ package com.dmdirc.parser.irc;
 import com.dmdirc.parser.common.ChannelListModeItem;
 import com.dmdirc.parser.common.ParserError;
 import com.dmdirc.parser.common.QueuePriority;
+import com.dmdirc.parser.events.ChannelPasswordChangedEvent;
 import com.dmdirc.parser.interfaces.ChannelClientInfo;
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.ClientInfo;
@@ -454,6 +455,7 @@ public class IRCChannelInfo implements ChannelInfo {
      */
     public void setInternalPassword(final String newValue) {
         password = newValue;
+        parser.getCallbackManager().publish(new ChannelPasswordChangedEvent(parser, LocalDateTime.now(), this));
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/IRCChannelInfo.java
+++ b/irc/src/com/dmdirc/parser/irc/IRCChannelInfo.java
@@ -72,6 +72,8 @@ public class IRCChannelInfo implements ChannelInfo {
     private final PrefixModeManager prefixModeManager;
     /** Channel Name. */
     private final String name;
+    /** Channel Key. */
+    private String password = "";
     /** Hashtable containing references to ChannelClients. */
     private final Map<String, IRCChannelClientInfo> clients = Collections.synchronizedMap(new HashMap<>());
     /** Hashtable storing values for modes set in the channel that use parameters. */
@@ -440,6 +442,20 @@ public class IRCChannelInfo implements ChannelInfo {
         return topicUser;
     }
 
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * Set the internal value of the channel password,
+     *
+     * @param newValue New Value to set
+     */
+    public void setInternalPassword(final String newValue) {
+        password = newValue;
+    }
+
     /**
      * Set the channel modes.
      *
@@ -487,6 +503,13 @@ public class IRCChannelInfo implements ChannelInfo {
             }
         } else {
             paramModes.put(cMode, sValue);
+            if (cMode == 'k') {
+                if (sValue.equalsIgnoreCase("*") && !getPassword().equalsIgnoreCase("*")) {
+                    // Don't overwrite a guessed password with a hidden one.
+                    return;
+                }
+                setInternalPassword(sValue);
+            }
         }
     }
 


### PR DESCRIPTION
 - Parses outgoing JOINs to try and guess keys before we get the MODE reply.
   - Parsing algorithm based on Quakenet/Hybrid handling of keys.
     - Keys are swallowed from the key-list for EVERY channel that is
       to join, even if it is not needed, so you would need to use
       "JOIN #Foo,#Bar,#Baz Foo,,Baz" to join keyed channels #Foo and #Baz.
 - Key changes by mode +k and -k will be tracked.
 - Ignores attempts to set the key as "*" if we know a "better" key.
   - Side effect: If the key is actually set to "*" we can only learn it if that
     is what we join with, or it gets changed to that from no-key.