### PR TITLE
Make ProcessJoin handle the pendingJoins queue.

### DIFF
--- a/irc/src/com/dmdirc/parser/irc/IRCParser.java
+++ b/irc/src/com/dmdirc/parser/irc/IRCParser.java
@@ -47,6 +47,7 @@ import com.dmdirc.parser.interfaces.Encoder;
 import com.dmdirc.parser.interfaces.EncodingParser;
 import com.dmdirc.parser.interfaces.SecureParser;
 import com.dmdirc.parser.irc.IRCReader.ReadLine;
+import com.dmdirc.parser.irc.events.IRCDataOutEvent;
 import com.dmdirc.parser.irc.outputqueue.OutputQueue;
 
 import java.io.IOException;
@@ -234,10 +235,6 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
     private final WhoisResponseHandler whoisHandler;
     /** Used to synchronize calls to resetState. */
     private final Object resetStateSync = new Object();
-    /** Pending Joins. */
-    private final Queue<String> pendingJoins = new LinkedList<>();
-    /** Pending Join Keys. */
-    private final Queue<String> pendingJoinKeys = new LinkedList<>();
 
     /**
      * Default constructor, ServerInfo and MyInfo need to be added separately (using IRC.me and IRC.server).
@@ -551,7 +548,7 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
      * @param fromParser True if parser sent the data, false if sent using .sendLine
      */
     protected void callDataOut(final String data, final boolean fromParser) {
-        getCallbackManager().publish(new DataOutEvent(this, LocalDateTime.now(), data));
+        getCallbackManager().publish(new IRCDataOutEvent(this, LocalDateTime.now(), data));
     }
 
     /**
@@ -1059,48 +1056,9 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
                     }
                 }
             }
-        } else if ("join".equalsIgnoreCase(newLine[0]) && newLine.length > 1) {
-            final Queue<String> keys = new LinkedList<>();
-
-            if (newLine.length > 2) {
-                keys.addAll(Arrays.asList(newLine[2].split(",")));
-            }
-
-            // PendingJoins and PendingJoinKeys should always be the same length (even if no key was given).
-            //
-            // We don't get any errors for channels we try to join that we are already in
-            // But the IRCD will still swallow the key attempt.
-            //
-            // Make sure that we always have a guessed key for every channel (even if null) and that we
-            // don't have guesses for channels we are already in.
-            for (final String chan : newLine[1].split(",")) {
-                final String key = keys.poll();
-                if (getChannel(chan) == null) {
-                    pendingJoins.add(chan);
-                    pendingJoinKeys.add(key);
-                }
-            }
         }
 
         return true;
-    }
-
-    /**
-     * Get the current pending Joins.
-     *
-     * @return Current pending Joins
-     */
-    public Queue<String> getPendingJoins() {
-        return pendingJoins;
-    }
-
-    /**
-     * Get the current pending join keys.
-     *
-     * @return Current pending join keys.
-     */
-    public Queue<String> getPendingJoinKeys() {
-        return pendingJoinKeys;
     }
 
     @Override

--- a/irc/src/com/dmdirc/parser/irc/events/IRCDataOutEvent.java
+++ b/irc/src/com/dmdirc/parser/irc/events/IRCDataOutEvent.java
@@ -32,6 +32,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Called on every outgoing line BEFORE being sent.
+ *
+ * This extends the standard DataOutEvent to also pre-tokenise the data.
  */
 public class IRCDataOutEvent extends DataOutEvent {
 

--- a/irc/src/com/dmdirc/parser/irc/events/IRCDataOutEvent.java
+++ b/irc/src/com/dmdirc/parser/irc/events/IRCDataOutEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2015 DMDirc Developers
+ * Copyright (c) 2006-2014 DMDirc Developers
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,9 +20,11 @@
  * SOFTWARE.
  */
 
-package com.dmdirc.parser.events;
+package com.dmdirc.parser.irc.events;
 
+import com.dmdirc.parser.events.DataOutEvent;
 import com.dmdirc.parser.interfaces.Parser;
+import com.dmdirc.parser.irc.IRCParser;
 
 import java.time.LocalDateTime;
 
@@ -31,16 +33,22 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called on every outgoing line BEFORE being sent.
  */
-public class DataOutEvent extends ParserEvent {
+public class IRCDataOutEvent extends DataOutEvent {
 
-    private final String data;
+    private final String[] tokenisedData;
+    private final String action;
 
-    public DataOutEvent(final Parser parser, final LocalDateTime date, final String data) {
-        super(parser, date);
-        this.data = checkNotNull(data);
+    public IRCDataOutEvent(final Parser parser, final LocalDateTime date, final String data) {
+        super(parser, date, data);
+        tokenisedData = IRCParser.tokeniseLine(checkNotNull(data));
+        action = tokenisedData[0].toUpperCase();
     }
 
-    public String getData() {
-        return data;
+    public String[] getTokenisedData() {
+        return tokenisedData;
+    }
+
+    public String getAction() {
+        return action;
     }
 }

--- a/irc/src/com/dmdirc/parser/irc/processors/ProcessJoin.java
+++ b/irc/src/com/dmdirc/parser/irc/processors/ProcessJoin.java
@@ -204,7 +204,7 @@ public class ProcessJoin extends IRCProcessor {
         }
     }
 
-    @Handler(delivery = Invoke.Synchronously, condition = "msg.action == 'JOIN'")
+    @Handler(condition = "msg.action == 'JOIN'")
     public void handleDataOut(final IRCDataOutEvent event) {
         // As long as this is called before the resulting DataIn
         // Processors fire then this will work, otherwise we'll end


### PR DESCRIPTION
Make ProcessJoin handle the pendingJoins queue rather than the parser itself.

(#108)