### PR TITLE
Add IRCDataInEvent that presents a ReadLine object rather than just the line of data.

### DIFF
--- a/common/src/com/dmdirc/parser/events/DataInEvent.java
+++ b/common/src/com/dmdirc/parser/events/DataInEvent.java
@@ -29,7 +29,7 @@ import java.time.LocalDateTime;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Interface Used on every incoming line BEFORE parsing.
+ * Called on every incoming line BEFORE parsing.
  */
 public class DataInEvent extends ParserEvent {
 

--- a/irc/src/com/dmdirc/parser/irc/IRCParser.java
+++ b/irc/src/com/dmdirc/parser/irc/IRCParser.java
@@ -47,6 +47,7 @@ import com.dmdirc.parser.interfaces.Encoder;
 import com.dmdirc.parser.interfaces.EncodingParser;
 import com.dmdirc.parser.interfaces.SecureParser;
 import com.dmdirc.parser.irc.IRCReader.ReadLine;
+import com.dmdirc.parser.irc.events.IRCDataInEvent;
 import com.dmdirc.parser.irc.events.IRCDataOutEvent;
 import com.dmdirc.parser.irc.outputqueue.OutputQueue;
 
@@ -535,10 +536,10 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
     /**
      * Callback to all objects implementing the DataIn Callback.
      *
-     * @param data Incoming Line.
+     * @param line Incoming Line.
      */
-    protected void callDataIn(final String data) {
-        getCallbackManager().publish(new DataInEvent(this, LocalDateTime.now(), data));
+    protected void callDataIn(final ReadLine line) {
+        getCallbackManager().publish(new IRCDataInEvent(this, LocalDateTime.now(), line));
     }
 
     /**
@@ -1085,7 +1086,7 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
      */
     @SuppressWarnings("fallthrough")
     protected void processLine(final ReadLine line) {
-        callDataIn(line.getLine());
+        callDataIn(line);
         final String[] token = line.getTokens();
         LocalDateTime lineTS = LocalDateTime.now();
 

--- a/irc/src/com/dmdirc/parser/irc/events/IRCDataInEvent.java
+++ b/irc/src/com/dmdirc/parser/irc/events/IRCDataInEvent.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2006-2014 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.parser.irc.events;
+
+import com.dmdirc.parser.events.DataInEvent;
+import com.dmdirc.parser.interfaces.Parser;
+import com.dmdirc.parser.irc.IRCParser;
+import com.dmdirc.parser.irc.IRCReader.ReadLine;
+
+import java.time.LocalDateTime;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Called on every incoming line BEFORE parsing.
+ *
+ * This extends the standard DataInEvent to provide access to IRC-Specific bits.
+ */
+public class IRCDataInEvent extends DataInEvent {
+
+    private final ReadLine line;
+    private final String[] tokenisedData;
+    private final String action;
+
+    public IRCDataInEvent(final IRCParser parser, final LocalDateTime date, final ReadLine line) {
+        super(parser, date, checkNotNull(line).getLine());
+        this.line = line;
+        tokenisedData = line.getTokens();
+
+        // Action is slightly more complicated than for DataOut
+        if (tokenisedData.length > 1) {
+            if (tokenisedData[0].length() > 0 && tokenisedData[0].charAt(0) == ':') {
+                if (tokenisedData[1].equalsIgnoreCase("NOTICE") && !parser.got001) {
+                    action = "NOTICE AUTH";
+                } else {
+                    action = tokenisedData[1].toUpperCase();
+                }
+            } else if (tokenisedData[0].equalsIgnoreCase("NOTICE")) {
+                action = "NOTICE AUTH";
+            } else {
+                action = tokenisedData[0].toUpperCase();
+            }
+        } else {
+            action = "";
+        }
+    }
+
+    public String[] getTokenisedData() {
+        return tokenisedData;
+    }
+
+    public ReadLine getLine() {
+        return line;
+    }
+
+    public String getAction() {
+        return action;
+    }
+}


### PR DESCRIPTION
This gives us access to MessageTags (#19) and pre-tokenised lines in DataIn rather than everything needing to tokenise themselves.

There are probably a few other events we want to expose messagetags on that we still don't but this is a start.