### PR TITLE
Use proper dates in QueueItems, fix broken logic.

### DIFF
--- a/irc/src/com/dmdirc/parser/irc/outputqueue/QueueHandler.java
+++ b/irc/src/com/dmdirc/parser/irc/outputqueue/QueueHandler.java
@@ -25,6 +25,8 @@ package com.dmdirc.parser.irc.outputqueue;
 import com.dmdirc.parser.common.QueuePriority;
 
 import java.io.PrintWriter;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.concurrent.BlockingQueue;
 
@@ -99,7 +101,8 @@ public abstract class QueueHandler extends Thread implements Comparator<QueueIte
      */
     @Override
     public int compare(final QueueItem mainObject, final QueueItem otherObject) {
-        if (mainObject.getTime() < 10 * 1000 && mainObject.getPriority().compareTo(otherObject.getPriority()) != 0) {
+        if (!isStarved(mainObject)
+                && mainObject.getPriority().compareTo(otherObject.getPriority()) != 0) {
             return mainObject.getPriority().compareTo(otherObject.getPriority());
         }
 
@@ -111,6 +114,17 @@ public abstract class QueueHandler extends Thread implements Comparator<QueueIte
             // This can't happen.
             return 0;
         }
+    }
+
+    /**
+     * Determines whether the given item has been starved (i.e., it has sat waiting in the queue
+     * for too long due to higher priority items).
+     *
+     * @param item The item to check
+     * @return True if the item has been queued for longer than 10 seconds, false otherwise
+     */
+    private static boolean isStarved(final QueueItem item) {
+        return item.getTime().isBefore(LocalDateTime.now().minus(10, ChronoUnit.SECONDS));
     }
 
     /**

--- a/irc/src/com/dmdirc/parser/irc/outputqueue/QueueItem.java
+++ b/irc/src/com/dmdirc/parser/irc/outputqueue/QueueItem.java
@@ -24,6 +24,8 @@ package com.dmdirc.parser.irc.outputqueue;
 
 import com.dmdirc.parser.common.QueuePriority;
 
+import java.time.LocalDateTime;
+
 /**
  * Queued Item.
  */
@@ -34,7 +36,7 @@ public class QueueItem implements Comparable<QueueItem> {
     /** Line to send. */
     private final String line;
     /** Time this line was added. */
-    private final long time;
+    private final LocalDateTime time;
     /** Item Number. */
     private final long itemNumber;
     /** What is the priority of this line? */
@@ -54,7 +56,7 @@ public class QueueItem implements Comparable<QueueItem> {
         this.line = line;
         this.priority = priority;
 
-        this.time = System.currentTimeMillis();
+        this.time = LocalDateTime.now();
         this.itemNumber = number++;
     }
 
@@ -68,11 +70,11 @@ public class QueueItem implements Comparable<QueueItem> {
     }
 
     /**
-     * Get the value of time.
+     * Gets the time at which this item was queued.
      *
-     * @return the value of time
+     * @return the time this item was queued.
      */
-    public long getTime() {
+    public LocalDateTime getTime() {
         return time;
     }
 


### PR DESCRIPTION
Use Java8 date types for parser queue items. Fix the time check in
QueueHandler to check if the item has been queued for longer than
10 seconds, rather than if the item was created within 10 seconds
of the epoch.