### PR TITLE
Don't pass BlockingQueue into handlers.

### DIFF
--- a/irc/src/com/dmdirc/parser/irc/outputqueue/OutputQueue.java
+++ b/irc/src/com/dmdirc/parser/irc/outputqueue/OutputQueue.java
@@ -134,6 +134,15 @@ public class OutputQueue {
     }
 
     /**
+     * Direct access to the queue of items waiting to be sent.
+     *
+     * @return This queue's backing queue.
+     */
+    public BlockingQueue<QueueItem> getQueue() {
+        return queue;
+    }
+
+    /**
      * Should we be discarding?
      *
      * @param newValue true to enable discarding.
@@ -204,7 +213,7 @@ public class OutputQueue {
         if (queueEnabled && priority != QueuePriority.IMMEDIATE) {
             synchronized (queueHandlerLock) {
                 if (queueHandler == null || !queueHandler.isAlive()) {
-                    queueHandler = queueHandlerFactory.getQueueHandler(this, queue, out);
+                    queueHandler = queueHandlerFactory.getQueueHandler(this, out);
                     queueHandler.start();
                 }
 

--- a/irc/src/com/dmdirc/parser/irc/outputqueue/PriorityQueueHandler.java
+++ b/irc/src/com/dmdirc/parser/irc/outputqueue/PriorityQueueHandler.java
@@ -24,7 +24,6 @@ package com.dmdirc.parser.irc.outputqueue;
 
 import java.io.PrintWriter;
 import java.time.Duration;
-import java.util.concurrent.BlockingQueue;
 
 /**
  * This does no rate limiting, and just sends based on priority.
@@ -35,15 +34,12 @@ public class PriorityQueueHandler extends QueueHandler {
      * Create a new PriorityQueueHandler.
      *
      * @param outputQueue Owner of this Queue Handler
-     * @param queue Queue to use
      * @param out Output Stream to use
      */
     public PriorityQueueHandler(
             final OutputQueue outputQueue,
-            final BlockingQueue<QueueItem> queue,
             final PrintWriter out) {
         super(outputQueue,
-                queue,
                 QueueComparators.byPriorityThenNumber(Duration.ofSeconds(10)),
                 out);
     }
@@ -61,7 +57,7 @@ public class PriorityQueueHandler extends QueueHandler {
     public void run() {
         try {
             while (outputQueue.isQueueEnabled()) {
-                final QueueItem item = queue.take();
+                final QueueItem item = outputQueue.getQueue().take();
 
                 sendLine(item.getLine());
             }

--- a/irc/src/com/dmdirc/parser/irc/outputqueue/QueueHandler.java
+++ b/irc/src/com/dmdirc/parser/irc/outputqueue/QueueHandler.java
@@ -28,15 +28,12 @@ import java.io.PrintWriter;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
-import java.util.concurrent.BlockingQueue;
 
 /**
  * Sending queue.
  */
 public abstract class QueueHandler extends Thread implements Comparator<QueueItem> {
 
-    /** Queue we are handling. */
-    protected final BlockingQueue<QueueItem> queue;
     /** The output queue that owns us. */
     protected OutputQueue outputQueue;
     /** Comparator to use to sort queue items. */
@@ -48,18 +45,15 @@ public abstract class QueueHandler extends Thread implements Comparator<QueueIte
      * Create a new Queue Thread.
      *
      * @param outputQueue the OutputQueue that owns us.
-     * @param queue Queue to handle.
      * @param comparator Comparator to use to sort items in the queue.
      * @param out Writer to send to.
      */
     public QueueHandler(
             final OutputQueue outputQueue,
-            final BlockingQueue<QueueItem> queue,
             final Comparator<QueueItem> comparator,
             final PrintWriter out) {
         super("IRC Parser queue handler");
 
-        this.queue = queue;
         this.comparator = comparator;
         this.out = out;
         this.outputQueue = outputQueue;

--- a/irc/src/com/dmdirc/parser/irc/outputqueue/QueueHandlerFactory.java
+++ b/irc/src/com/dmdirc/parser/irc/outputqueue/QueueHandlerFactory.java
@@ -23,7 +23,6 @@
 package com.dmdirc.parser.irc.outputqueue;
 
 import java.io.PrintWriter;
-import java.util.concurrent.BlockingQueue;
 
 /**
  * A QueueHandlerFactory produces QueueHandlers for OutputQueue.
@@ -34,10 +33,9 @@ public interface QueueHandlerFactory {
      * Get a new QueueHandler instance as needed.
      *
      * @param outputQueue the OutputQueue that will own this QueueHandler
-     * @param queue The queue to handle.
      * @param out Where to send crap.
      * @return the new queue handler object.
      */
-    QueueHandler getQueueHandler(final OutputQueue outputQueue,
-            final BlockingQueue<QueueItem> queue, final PrintWriter out);
+    QueueHandler getQueueHandler(final OutputQueue outputQueue, final PrintWriter out);
+
 }

--- a/irc/src/com/dmdirc/parser/irc/outputqueue/SimpleRateLimitedQueueHandler.java
+++ b/irc/src/com/dmdirc/parser/irc/outputqueue/SimpleRateLimitedQueueHandler.java
@@ -25,7 +25,6 @@ package com.dmdirc.parser.irc.outputqueue;
 import com.dmdirc.parser.common.QueuePriority;
 
 import java.io.PrintWriter;
-import java.util.concurrent.BlockingQueue;
 
 /**
  * This is a simple rate limiting queue.
@@ -54,14 +53,12 @@ public class SimpleRateLimitedQueueHandler extends QueueHandler {
      * Create a new SimpleRateLimitedQueueHandler.
      *
      * @param outputQueue Owner of this Queue Handler
-     * @param queue Queue to use
      * @param out Output Stream to use
      */
     public SimpleRateLimitedQueueHandler(
             final OutputQueue outputQueue,
-            final BlockingQueue<QueueItem> queue,
             final PrintWriter out) {
-        super(outputQueue, queue, QueueComparators.byPriorityThenNumber(), out);
+        super(outputQueue, QueueComparators.byPriorityThenNumber(), out);
     }
 
     /**
@@ -182,7 +179,7 @@ public class SimpleRateLimitedQueueHandler extends QueueHandler {
                 // It has been longer than limitTime and we are still shown as
                 // limiting, check to see if the queue is empty or not, if it is
                 // disable limiting.
-                if (queue.isEmpty()) {
+                if (outputQueue.getQueue().isEmpty()) {
                     isLimiting = false;
                 }
             } else {
@@ -203,14 +200,14 @@ public class SimpleRateLimitedQueueHandler extends QueueHandler {
     public void run() {
         try {
             while (outputQueue.isQueueEnabled()) {
-                final QueueItem item = queue.take();
+                final QueueItem item = outputQueue.getQueue().take();
 
                 sendLine(item.getLine());
 
                 final boolean doSleep;
                 synchronized (this) {
                     doSleep = isLimiting;
-                    if (isLimiting && queue.isEmpty()) {
+                    if (isLimiting && outputQueue.getQueue().isEmpty()) {
                         isLimiting = false;
                     }
                 }


### PR DESCRIPTION
Handlers provide the comparator used by BlockingQueues, creating
a circular dependency.