### PR TITLE
Add framework for parser integration tests.

### DIFF
--- a/irc/build.gradle
+++ b/irc/build.gradle
@@ -1,3 +1,21 @@
+sourceSets {
+    integTest {
+        java.srcDirs = ['integ-test']
+    }
+}
+
+task integTest(type: Test) {
+    testClassesDir = sourceSets.integTest.output.classesDir
+    classpath = sourceSets.integTest.runtimeClasspath
+}
+
+check.dependsOn integTest
+
 dependencies {
     compile find("common")
+    integTestCompile sourceSets.main.output
+    integTestCompile configurations.testCompile
+    integTestCompile sourceSets.test.output
+    integTestCompile group: 'com.github.docker-java', name: 'docker-java', version: '3.0.0'
+    integTestRuntime configurations.testRuntime
 }

--- a/irc/integ-test/com/dmdirc/parser/irc/integration/ExampleTest.java
+++ b/irc/integ-test/com/dmdirc/parser/irc/integration/ExampleTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2006-2016 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.parser.irc.integration;
+
+import com.dmdirc.parser.events.ServerReadyEvent;
+import com.dmdirc.parser.interfaces.Parser;
+import com.dmdirc.parser.irc.IRCParser;
+import com.dmdirc.parser.irc.integration.util.DockerContainerRule;
+
+import java.net.URI;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import net.engio.mbassy.listener.Handler;
+import net.engio.mbassy.listener.Listener;
+import net.engio.mbassy.listener.References;
+
+public class ExampleTest {
+
+    @Rule
+    public final DockerContainerRule containerRule =
+            new DockerContainerRule("cloudposse/unrealircd");
+
+    @Test
+    public void testBasicConnect() throws InterruptedException {
+        final Parser ircParser = new IRCParser(URI.create(
+                "irc://" + containerRule.getContainerIpAddress()));
+        final ConnectListener listener = new ConnectListener();
+        ircParser.getCallbackManager().subscribe(listener);
+        ircParser.connect();
+        listener.connected.tryAcquire(2500, TimeUnit.MILLISECONDS);
+    }
+
+    @Listener(references = References.Strong)
+    private static final class ConnectListener {
+
+        final Semaphore connected = new Semaphore(0);
+
+        @Handler
+        public void onConnect(final ServerReadyEvent event) {
+            connected.release();
+        }
+
+    }
+
+
+} 

--- a/irc/integ-test/com/dmdirc/parser/irc/integration/util/DockerContainerRule.java
+++ b/irc/integ-test/com/dmdirc/parser/irc/integration/util/DockerContainerRule.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2006-2016 DMDirc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dmdirc.parser.irc.integration.util;
+
+import com.google.common.collect.Iterables;
+
+import org.junit.Assume;
+import org.junit.rules.ExternalResource;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.ContainerNetwork;
+import com.github.dockerjava.core.DockerClientBuilder;
+import com.github.dockerjava.core.command.PullImageResultCallback;
+
+/**
+ * Rule that launchers a container with a given image, and tears it down on completion.
+ */
+public class DockerContainerRule extends ExternalResource {
+
+    private final String image;
+    private DockerClient client;
+    private String container;
+    private String ip;
+
+    public DockerContainerRule(final String image) {
+        this.image = image;
+    }
+
+    @Override
+    @SuppressWarnings("resource")
+    protected void before() throws Throwable {
+        super.before();
+
+        client = DockerClientBuilder.getInstance().build();
+        client.pullImageCmd(image).exec(new PullImageResultCallback()).awaitSuccess();
+
+        container = client.createContainerCmd(image).exec().getId();
+        client.startContainerCmd(container).exec();
+
+        final ContainerNetwork network = Iterables.getFirst(
+                client.inspectContainerCmd(container)
+                        .exec()
+                        .getNetworkSettings()
+                        .getNetworks().values(), null);
+        Assume.assumeNotNull(network);
+
+        ip = network.getIpAddress();
+    }
+
+    @Override
+    protected void after() {
+        super.after();
+
+        client.stopContainerCmd(container).exec();
+        client.removeContainerCmd(container).withForce(true).exec();
+    }
+
+    public String getContainerIpAddress() {
+        return ip;
+    }
+
+}


### PR DESCRIPTION
Using docker we can bring up and tear down IRCds pretty trivially.
This allows us to test the parser in real-world situations.