### PR TITLE
Remove chain of Comparators in output queue.

### DIFF
--- a/irc/src/com/dmdirc/parser/irc/outputqueue/QueueHandler.java
+++ b/irc/src/com/dmdirc/parser/irc/outputqueue/QueueHandler.java
@@ -25,14 +25,12 @@ package com.dmdirc.parser.irc.outputqueue;
 import com.dmdirc.parser.common.QueuePriority;
 
 import java.io.PrintWriter;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 
 /**
  * Sending queue.
  */
-public abstract class QueueHandler extends Thread implements Comparator<QueueItem> {
+public abstract class QueueHandler extends Thread {
 
     /** The output queue that owns us. */
     protected OutputQueue outputQueue;
@@ -80,23 +78,16 @@ public abstract class QueueHandler extends Thread implements Comparator<QueueIte
      * @return A QueueItem for teh given parameters
      */
     public QueueItem getQueueItem(final String line, final QueuePriority priority) {
-        return new QueueItem(this, line, priority);
-    }
-
-    @Override
-    public int compare(final QueueItem mainObject, final QueueItem otherObject) {
-        return comparator.compare(mainObject, otherObject);
+        return new QueueItem(line, priority);
     }
 
     /**
-     * Determines whether the given item has been starved (i.e., it has sat waiting in the queue
-     * for too long due to higher priority items).
+     * Gets the comparator to use to sort queue items.
      *
-     * @param item The item to check
-     * @return True if the item has been queued for longer than 10 seconds, false otherwise
+     * @return The comparator to use to sort queue items.
      */
-    private static boolean isStarved(final QueueItem item) {
-        return item.getTime().isBefore(LocalDateTime.now().minus(10, ChronoUnit.SECONDS));
+    public Comparator<QueueItem> getQueueItemComparator() {
+        return comparator;
     }
 
     /**
@@ -108,4 +99,5 @@ public abstract class QueueHandler extends Thread implements Comparator<QueueIte
      */
     @Override
     public abstract void run();
+
 }

--- a/irc/src/com/dmdirc/parser/irc/outputqueue/QueueItem.java
+++ b/irc/src/com/dmdirc/parser/irc/outputqueue/QueueItem.java
@@ -30,7 +30,7 @@ import java.time.LocalDateTime;
 /**
  * Queued Item.
  */
-public class QueueItem implements Comparable<QueueItem> {
+public class QueueItem {
 
     /** Global Item Number. */
     private static long number;
@@ -42,30 +42,25 @@ public class QueueItem implements Comparable<QueueItem> {
     private final long itemNumber;
     /** What is the priority of this line? */
     private final QueuePriority priority;
-    /** Our handler. */
-    private final QueueHandler handler;
 
     /**
      * Create a new QueueItem.
      *
-     * @param handler Handler for this QueueItem
      * @param line Line to send
      * @param priority Priority for the queue item
      */
-    public QueueItem(final QueueHandler handler, final String line, final QueuePriority priority) {
-        this(handler, Clock.systemDefaultZone(), line, priority);
+    public QueueItem(final String line, final QueuePriority priority) {
+        this(Clock.systemDefaultZone(), line, priority);
     }
 
     /**
      * Create a new QueueItem.
      *
-     * @param handler Handler for this QueueItem
      * @param line Line to send
      * @param priority Priority for the queue item
      */
-    public QueueItem(final QueueHandler handler, final Clock clock, final String line,
+    public QueueItem(final Clock clock, final String line,
             final QueuePriority priority) {
-        this.handler = handler;
         this.line = line;
         this.priority = priority;
 
@@ -109,20 +104,9 @@ public class QueueItem implements Comparable<QueueItem> {
         return priority;
     }
 
-    /**
-     * Compare objects.
-     * This will use the compareQueueItem method of the current QueueHandler.
-     *
-     * @param o Object to compare to
-     * @return Position of this item in reference to the given item.
-     */
-    @Override
-    public int compareTo(final QueueItem o) {
-        return handler.compare(this, o);
-    }
-
     @Override
     public String toString() {
-        return String.format("[%s %d] %s", priority, time, line);
+        return String.format("[%s %s] %s", priority, time, line);
     }
+
 }

--- a/irc/test/com/dmdirc/parser/irc/outputqueue/QueueComparatorsTest.java
+++ b/irc/test/com/dmdirc/parser/irc/outputqueue/QueueComparatorsTest.java
@@ -45,19 +45,19 @@ public class QueueComparatorsTest {
     private static final Clock NOW_MINUS_TEN = Clock.fixed(Instant.ofEpochMilli(90 * 1000),
             ZoneId.systemDefault());
 
-    private final QueueItem currentLowPriority1 = new QueueItem(null, NOW_MINUS_FIVE,
+    private final QueueItem currentLowPriority1 = new QueueItem(NOW_MINUS_FIVE,
             "", QueuePriority.LOW);
 
-    private final QueueItem currentLowPriority2 = new QueueItem(null, NOW_MINUS_FIVE,
+    private final QueueItem currentLowPriority2 = new QueueItem(NOW_MINUS_FIVE,
             "", QueuePriority.LOW);
 
-    private final QueueItem currentNormalPriority = new QueueItem(null, NOW_MINUS_FIVE,
+    private final QueueItem currentNormalPriority = new QueueItem(NOW_MINUS_FIVE,
             "", QueuePriority.NORMAL);
 
-    private final QueueItem currentHighPriority = new QueueItem(null, NOW_MINUS_FIVE,
+    private final QueueItem currentHighPriority = new QueueItem(NOW_MINUS_FIVE,
             "", QueuePriority.HIGH);
 
-    private final QueueItem oldLowPriority = new QueueItem(null, NOW_MINUS_TEN,
+    private final QueueItem oldLowPriority = new QueueItem(NOW_MINUS_TEN,
             "", QueuePriority.LOW);
 
     @Test


### PR DESCRIPTION
Instead of having lots of objects implement Comparable or Comparator,
pass the comparator in to the PriorityBlockingQueue.

This requires recreating the queue if the QueueHandler is ever changed,
but the previous behaviour resulted in an unstable/undefined ordering,
so it's probably better this way anyway.

This means that QueueItems no longer need to know about QueueHandler,
which makes me slightly happier.