### PR TITLE
Remove default port from ProtocolDescription.

### DIFF
--- a/common/src/main/java/com/dmdirc/parser/interfaces/ProtocolDescription.java
+++ b/common/src/main/java/com/dmdirc/parser/interfaces/ProtocolDescription.java
@@ -33,13 +33,6 @@ import java.net.URI;
 public interface ProtocolDescription {
 
     /**
-     * Retrieves the default port to use for this protocol if none is specified.
-     *
-     * @return This protocol's default port
-     */
-    int getDefaultPort();
-
-    /**
      * Parses the specified hostmask into an array containing a nickname,
      * username and hostname, in that order.
      *

--- a/irc/src/main/java/com/dmdirc/parser/irc/IRCProtocolDescription.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/IRCProtocolDescription.java
@@ -34,11 +34,6 @@ import java.net.URI;
 public class IRCProtocolDescription implements ProtocolDescription {
 
     @Override
-    public int getDefaultPort() {
-        return 6667;
-    }
-
-    @Override
     public String[] parseHostmask(final String hostmask) {
         return IRCClientInfo.parseHostFull(hostmask);
     }

--- a/xmpp/src/main/java/com/dmdirc/parser/xmpp/XmppProtocolDescription.java
+++ b/xmpp/src/main/java/com/dmdirc/parser/xmpp/XmppProtocolDescription.java
@@ -32,11 +32,6 @@ import java.net.URI;
 public class XmppProtocolDescription implements ProtocolDescription {
 
     @Override
-    public int getDefaultPort() {
-        return 5222;
-    }
-
-    @Override
     public String[] parseHostmask(final String hostmask) {
         final String[] parts = hostmask.split("/");
         return new String[]{parts[0], parts.length > 1 ? parts[1] : "unknown", ""};


### PR DESCRIPTION
If the user doesn't specify a port, the parser should decide what
to do itself. A single default port isn't useful to users of the
parser.