### PR TITLE
Add config for pushing snapshots from circle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,11 @@ subprojects {
         repositories {
             maven {
                 name 'snapshots'
-                url 'http://artifactory.dmdirc.com/artifactory/repo'
+                url 'http://artifactory.dmdirc.com/artifactory/snapshots'
+                credentials {
+                    username System.getenv('ARTIFACTORY_USER')
+                    password System.getenv('ARTIFACTORY_PASSWORD')
+                }
             }
         }
     }

--- a/circle.yml
+++ b/circle.yml
@@ -18,3 +18,10 @@ dependencies:
 test:
   override:
     - ./gradlew test jacocoTestReport coveralls
+
+deployment:
+  snapshots:
+    branch: master
+    owner: DMDirc
+    commands:
+      - ./gradlew publishSnapshot


### PR DESCRIPTION
Circle is configured with a user/pass in secure env vars
(not exposed to builds from forks).

In theory this allows it to push master builds to artifactory's
snapshot repository.