### PR TITLE
Support for tsirc alongside message tags. Close #149

### DIFF
--- a/irc/src/main/java/com/dmdirc/parser/irc/IRCParser.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/IRCParser.java
@@ -929,17 +929,20 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
         // Check for IRC Tags.
         if (line.charAt(0) == '@') {
             // We have tags.
+            boolean hasIRCv3Tags = true;
             tokens = line.split(" ", 2);
             final int tsEnd = tokens[0].indexOf('@', 1);
-            boolean hasTSIRCDate = false;
             if (tsEnd > -1) {
                 try {
                     final long ts = Long.parseLong(tokens[0].substring(1, tsEnd));
-                    hasTSIRCDate = true;
+
+                    // We might have both IRCv3 tags and TSIRC, with TSIRC first, eg:
+                    // @123@@tag=value :test ing
+                    hasIRCv3Tags = tokens[0].length() > tsEnd && tokens[0].charAt(tsEnd) == '@';
                 } catch (final NumberFormatException nfe) { /* Not a timestamp. */ }
             }
 
-            if (!hasTSIRCDate) {
+            if (hasIRCv3Tags) {
                 // IRCv3 Tags, last arg is actually the second " :"
                 lastarg = line.indexOf(" :", lastarg+1);
             }

--- a/irc/src/main/java/com/dmdirc/parser/irc/IRCReader.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/IRCReader.java
@@ -32,7 +32,6 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/irc/src/test/java/com/dmdirc/parser/irc/IRCReaderTest.java
+++ b/irc/src/test/java/com/dmdirc/parser/irc/IRCReaderTest.java
@@ -208,6 +208,28 @@ public class IRCReaderTest {
         assertNull(line.getTags().get("time"));
     }
 
+    /** Verify tokeniser with TSIRC Time Stamp and Message Tags (tags first). */
+    @Test
+    public void testReadLineTSIRCandTag() throws IOException {
+        final ReadLine line = new ReadLine("", IRCParser.tokeniseLine("@tag=value @123@:test ing"));
+
+        assertEquals(":test", line.getTokens()[0]);
+        assertEquals("ing", line.getTokens()[1]);
+        assertEquals("123", line.getTags().get("tsirc date"));
+        assertEquals("value", line.getTags().get("tag"));
+    }
+
+    /** Verify tokeniser with TSIRC Time Stamp and Message Tags (tags second). */
+    @Test
+    public void testReadLineTSIRCandTag2() throws IOException {
+        final ReadLine line = new ReadLine("", IRCParser.tokeniseLine("@123@@tag=value :test ing"));
+
+        assertEquals(":test", line.getTokens()[0]);
+        assertEquals("ing", line.getTokens()[1]);
+        assertEquals("123", line.getTags().get("tsirc date"));
+        assertEquals("value", line.getTags().get("tag"));
+    }
+
     /** Verify tokeniser with IRCv3 tags */
     @Test
     public void testReadLineIRCv3TS() throws IOException {


### PR DESCRIPTION
Eg, allow:
```
@123@@tag=value :test ing
@tag=value @123@:test ing
```

to both represent the same message.