### PR TITLE
Allow parser sub-classes to redefine the callback manager

### DIFF
--- a/common/src/main/java/com/dmdirc/parser/common/BaseParser.java
+++ b/common/src/main/java/com/dmdirc/parser/common/BaseParser.java
@@ -72,7 +72,7 @@ public abstract class BaseParser extends ThreadedParser {
     private URI proxy;
 
     /** The callback manager to use for this parser. */
-    private final CallbackManager callbackManager;
+    private CallbackManager callbackManager;
 
     /**
      * Creates a new base parser for the specified URI.
@@ -90,7 +90,7 @@ public abstract class BaseParser extends ThreadedParser {
             "CallToPrintStackTrace",
             "UseOfSystemOutOrSystemErr"
     })
-    private void handleCallbackError(final PublicationError e) {
+    protected void handleCallbackError(final PublicationError e) {
         if (Thread.holdsLock(errorHandlerLock)) {
             // ABORT ABORT ABORT - we're publishing an error on the same thread we just tried
             // to publish an error on. Something in the error reporting pipeline must be
@@ -173,6 +173,23 @@ public abstract class BaseParser extends ThreadedParser {
     @Override
     public CallbackManager getCallbackManager() {
         return callbackManager;
+    }
+
+    /**
+     * Change the {@link CallbackManager} in use by this parser.
+     *
+     * This will shutdown the old CallbackManager before setting the new one.
+     *
+     * Subscribers are not carried across between callback managers.
+     *
+     * @param manager new CallbackManager to use (ignored if null)
+     */
+    protected void setCallbackManager(final CallbackManager manager) {
+        if (manager == null) {
+            return;
+        }
+        callbackManager.shutdown();
+        callbackManager = manager;
     }
 
     @Override

--- a/common/src/main/java/com/dmdirc/parser/common/BaseParser.java
+++ b/common/src/main/java/com/dmdirc/parser/common/BaseParser.java
@@ -185,9 +185,9 @@ public abstract class BaseParser extends ThreadedParser {
      */
     protected void setCallbackManager(final CallbackManager manager) {
         if (manager == null) {
-            throw new UnsupportedOperationException("setCallbackManager can not be called with a null parameter.");
+            throw new NullPointerException("setCallbackManager can not be called with a null parameter.");
         } else if (callbackManager != null) {
-            throw new UnsupportedOperationException("setCallbackManager can only be called once.");
+            throw new IllegalStateException("setCallbackManager can only be called once.");
         }
         callbackManager = manager;
     }

--- a/irc/src/main/java/com/dmdirc/parser/irc/IRCParser.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/IRCParser.java
@@ -274,6 +274,7 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
      */
     public IRCParser(final MyInfo myDetails, final URI uri) {
         super(uri);
+        setCallbackManager(new IRCParserCallbackManager(this::handleCallbackError));
 
         // TODO: There should be a factory or builder for parsers that can construct the graph
         final ObjectGraph graph = ObjectGraph.create(new IRCParserModule(this, prefixModes,

--- a/irc/src/main/java/com/dmdirc/parser/irc/IRCParserCallbackManager.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/IRCParserCallbackManager.java
@@ -34,6 +34,11 @@ import java.util.concurrent.TimeUnit;
 /**
  * Parser Callback Manager.
  * Manages adding/removing/calling callbacks.
+ *
+ * Because IRCParser was designed for synchronous callbacks not async events, we enforce synchronous publish only
+ * in this CallbackManager for now.
+ *
+ * This may change in future.
  */
 public class IRCParserCallbackManager extends CallbackManager {
     public IRCParserCallbackManager(final IPublicationErrorHandler errorHandler) {

--- a/irc/src/main/java/com/dmdirc/parser/irc/IRCParserCallbackManager.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/IRCParserCallbackManager.java
@@ -58,5 +58,4 @@ public class IRCParserCallbackManager extends CallbackManager {
     public IMessagePublication publishAsync(final ParserEvent message, final long timeout, final TimeUnit unit) {
         throw new UnsupportedOperationException("IRCParser does not support publishAsync");
     }
-
 }

--- a/irc/src/main/java/com/dmdirc/parser/irc/IRCParserCallbackManager.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/IRCParserCallbackManager.java
@@ -20,31 +20,38 @@
  * SOFTWARE.
  */
 
-package com.dmdirc.parser.common;
+package com.dmdirc.parser.irc;
 
+import com.dmdirc.parser.common.CallbackManager;
 import com.dmdirc.parser.events.ParserEvent;
-
-import net.engio.mbassy.bus.MBassador;
+import net.engio.mbassy.bus.IMessagePublication;
 import net.engio.mbassy.bus.config.BusConfiguration;
 import net.engio.mbassy.bus.config.Feature;
 import net.engio.mbassy.bus.error.IPublicationErrorHandler;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Parser Callback Manager.
  * Manages adding/removing/calling callbacks.
  */
-public class CallbackManager extends MBassador<ParserEvent> {
-
-    public CallbackManager(final IPublicationErrorHandler errorHandler) {
-        this(new BusConfiguration().addFeature(Feature.SyncPubSub.Default())
+public class IRCParserCallbackManager extends CallbackManager {
+    public IRCParserCallbackManager(final IPublicationErrorHandler errorHandler) {
+        super(new BusConfiguration().addFeature(Feature.SyncPubSub.Default())
                 .addFeature(Feature.AsynchronousHandlerInvocation.Default(1, 1))
                 .addFeature(Feature.AsynchronousMessageDispatch.Default()
-                        .setNumberOfMessageDispatchers(1))
+                        .setNumberOfMessageDispatchers(0))
                 .addPublicationErrorHandler(errorHandler));
     }
 
-    protected CallbackManager(final BusConfiguration busConfiguration) {
-        super(busConfiguration);
+    @Override
+    public IMessagePublication publishAsync(final ParserEvent message) {
+        throw new UnsupportedOperationException("IRCParser does not support publishAsync");
+    }
+
+    @Override
+    public IMessagePublication publishAsync(final ParserEvent message, final long timeout, final TimeUnit unit) {
+        throw new UnsupportedOperationException("IRCParser does not support publishAsync");
     }
 
 }


### PR DESCRIPTION
IRCParser was designed for synchronous callbacks not async events. We've moved to using an eventbus for the parser events, but for now we want to enforce that they are still used in a synchronous way rather than async for the time being to ensure that everything behaves.

(At a later date we can review if this is actually needed.)