### PR TITLE
Fix SimpleRateLimitedOutputQueue endlessly requeueing lines rather than sending them.

### DIFF
--- a/irc/src/main/java/com/dmdirc/parser/irc/outputqueue/SimpleRateLimitedOutputQueue.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/outputqueue/SimpleRateLimitedOutputQueue.java
@@ -184,7 +184,7 @@ public class SimpleRateLimitedOutputQueue extends OutputQueue {
     protected void handleQueuedItems() {
         try {
             while (isQueueEnabled()) {
-                sendLine(getQueue().take().getLine());
+                send(getQueue().take().getLine());
 
                 final boolean doSleep;
                 synchronized (this) {


### PR DESCRIPTION
After the changes to outputqueues a while back, this left SimpleRateLimitedOutputQueue broken, rather than sending lines to the server during handleQueuedItems() it was adding them back to itself and repeating this forever.