### PR TITLE
Add base class for channel events.

### DIFF
--- a/common/src/main/java/com/dmdirc/parser/events/ChannelActionEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelActionEvent.java
@@ -33,9 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when a person does an action in a channel.
  */
-public class ChannelActionEvent extends ParserEvent {
+public class ChannelActionEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
     private final String message;
     private final String host;
@@ -43,15 +42,10 @@ public class ChannelActionEvent extends ParserEvent {
     public ChannelActionEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String message,
             final String host) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.message = checkNotNull(message);
         this.host = checkNotNull(host);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelCTCPEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelCTCPEvent.java
@@ -33,9 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when a person sends a CTCP to a channel.
  */
-public class ChannelCTCPEvent extends ParserEvent {
+public class ChannelCTCPEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
     private final String type;
     private final String message;
@@ -44,16 +43,11 @@ public class ChannelCTCPEvent extends ParserEvent {
     public ChannelCTCPEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String type,
             final String message, final String host) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.type = checkNotNull(type);
         this.message = checkNotNull(message);
         this.host = checkNotNull(host);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelCTCPReplyEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelCTCPReplyEvent.java
@@ -33,9 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when a person sends a CTCPRReply to a channel.
  */
-public class ChannelCTCPReplyEvent extends ParserEvent {
+public class ChannelCTCPReplyEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
     private final String type;
     private final String message;
@@ -44,16 +43,11 @@ public class ChannelCTCPReplyEvent extends ParserEvent {
     public ChannelCTCPReplyEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String type,
             final String message, final String host) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.type = checkNotNull(type);
         this.message = checkNotNull(message);
         this.host = checkNotNull(host);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelEvent.java
@@ -26,20 +26,22 @@ import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
 import java.time.LocalDateTime;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
- * Called when the topic is changed or discovered for the first time.
+ * Base class for events that are tied to a {@link ChannelInfo}.
  */
-public class ChannelTopicEvent extends ChannelEvent {
+public abstract class ChannelEvent extends ParserEvent {
 
-    private final boolean isJoinTopic;
+    private final ChannelInfo channel;
 
-    public ChannelTopicEvent(final Parser parser, final LocalDateTime date,
-            final ChannelInfo channel, final boolean isJoinTopic) {
-        super(parser, date, channel);
-        this.isJoinTopic = isJoinTopic;
+    public ChannelEvent(final Parser parser, final LocalDateTime date, final ChannelInfo channel) {
+        super(parser, date);
+        this.channel = checkNotNull(channel);
     }
 
-    public boolean isJoinTopic() {
-        return isJoinTopic;
+    public ChannelInfo getChannel() {
+        return channel;
     }
+
 }

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelJoinEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelJoinEvent.java
@@ -33,20 +33,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called When we, or another client joins a channel.
  */
-public class ChannelJoinEvent extends ParserEvent {
+public class ChannelJoinEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
 
     public ChannelJoinEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelKickEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelKickEvent.java
@@ -33,9 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when a person is kicked.
  */
-public class ChannelKickEvent extends ParserEvent {
+public class ChannelKickEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo kickedClient;
     private final ChannelClientInfo client;
     private final String reason;
@@ -44,16 +43,11 @@ public class ChannelKickEvent extends ParserEvent {
     public ChannelKickEvent(final Parser parser, final LocalDateTime date, final ChannelInfo channel,
             final ChannelClientInfo kickedClient, final ChannelClientInfo client,
             final String reason, final String host) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.kickedClient = checkNotNull(kickedClient);
         this.client = checkNotNull(client);
         this.reason = checkNotNull(reason);
         this.host = checkNotNull(host);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getKickedClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelListModeEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelListModeEvent.java
@@ -24,28 +24,19 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
-
 import java.time.LocalDateTime;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Called when all requested ListModes have been sent.
  */
-public class ChannelListModeEvent extends ParserEvent {
+public class ChannelListModeEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final char mode;
 
     public ChannelListModeEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final char mode) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.mode = mode;
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public char getMode() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelMessageEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelMessageEvent.java
@@ -33,9 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when a person sends a message to a channel.
  */
-public class ChannelMessageEvent extends ParserEvent {
+public class ChannelMessageEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
     private final String message;
     private final String host;
@@ -43,15 +42,10 @@ public class ChannelMessageEvent extends ParserEvent {
     public ChannelMessageEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String message,
             final String host) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.message = checkNotNull(message);
         this.host = checkNotNull(host);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelModeChangeEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelModeChangeEvent.java
@@ -33,9 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when the channel modes are changed or discovered.
  */
-public class ChannelModeChangeEvent extends ParserEvent {
+public class ChannelModeChangeEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
     private final String host;
     private final String modes;
@@ -43,15 +42,10 @@ public class ChannelModeChangeEvent extends ParserEvent {
     public ChannelModeChangeEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String host,
             final String modes) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.host = checkNotNull(host);
         this.modes = checkNotNull(modes);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelModeMessageEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelModeMessageEvent.java
@@ -33,9 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when a person sends a Message to a channel with a mode prefix.
  */
-public class ChannelModeMessageEvent extends ParserEvent {
+public class ChannelModeMessageEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final char prefix;
     private final ChannelClientInfo client;
     private final String message;
@@ -44,16 +43,11 @@ public class ChannelModeMessageEvent extends ParserEvent {
     public ChannelModeMessageEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final char prefix, final ChannelClientInfo client,
             final String message, final String host) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
-        this.prefix = checkNotNull(prefix);
+        super(parser, date, channel);
+        this.prefix = prefix;
         this.client = checkNotNull(client);
         this.message = checkNotNull(message);
         this.host = checkNotNull(host);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public char getPrefix() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelModeNoticeEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelModeNoticeEvent.java
@@ -33,9 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when a person sends a notice to a channel with a mode prefix.
  */
-public class ChannelModeNoticeEvent extends ParserEvent {
+public class ChannelModeNoticeEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final char prefix;
     private final ChannelClientInfo client;
     private final String message;
@@ -44,16 +43,11 @@ public class ChannelModeNoticeEvent extends ParserEvent {
     public ChannelModeNoticeEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final char prefix, final ChannelClientInfo client,
             final String message, final String host) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
-        this.prefix = checkNotNull(prefix);
+        super(parser, date, channel);
+        this.prefix = prefix;
         this.client = checkNotNull(client);
         this.message = checkNotNull(message);
         this.host = checkNotNull(host);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public char getPrefix() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelNamesEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelNamesEvent.java
@@ -24,25 +24,16 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
-
 import java.time.LocalDateTime;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Called when a names reply is parsed.
  */
-public class ChannelNamesEvent extends ParserEvent {
-
-    private final ChannelInfo channel;
+public class ChannelNamesEvent extends ChannelEvent {
 
     public ChannelNamesEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
     }
 
-    public ChannelInfo getChannel() {
-        return channel;
-    }
 }

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelNickChangeEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelNickChangeEvent.java
@@ -33,22 +33,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when we or another user change nickname (Called once per channel the user is on).
  */
-public class ChannelNickChangeEvent extends ParserEvent {
+public class ChannelNickChangeEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
     private final String oldNick;
 
     public ChannelNickChangeEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String oldNick) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.oldNick = checkNotNull(oldNick);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelNonUserModeChangeEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelNonUserModeChangeEvent.java
@@ -33,9 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when the channel modes are changed or discovered.
  */
-public class ChannelNonUserModeChangeEvent extends ParserEvent {
+public class ChannelNonUserModeChangeEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
     private final String host;
     private final String modes;
@@ -43,15 +42,10 @@ public class ChannelNonUserModeChangeEvent extends ParserEvent {
     public ChannelNonUserModeChangeEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String host,
             final String modes) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.host = checkNotNull(host);
         this.modes = checkNotNull(modes);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelNoticeEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelNoticeEvent.java
@@ -33,25 +33,19 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when a person sends a notice to a channel.
  */
-public class ChannelNoticeEvent extends ParserEvent {
+public class ChannelNoticeEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
-    private final ChannelClientInfo client;
+        private final ChannelClientInfo client;
     private final String message;
     private final String host;
 
     public ChannelNoticeEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String message,
             final String host) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.message = checkNotNull(message);
         this.host = checkNotNull(host);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelOtherAwayStateEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelOtherAwayStateEvent.java
@@ -34,9 +34,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when we go away, or come back.
  */
-public class ChannelOtherAwayStateEvent extends ParserEvent {
+public class ChannelOtherAwayStateEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
     private final AwayState oldState;
     private final AwayState newState;
@@ -44,15 +43,10 @@ public class ChannelOtherAwayStateEvent extends ParserEvent {
     public ChannelOtherAwayStateEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final AwayState oldState,
             final AwayState newState) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.oldState = checkNotNull(oldState);
         this.newState = checkNotNull(newState);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelPartEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelPartEvent.java
@@ -33,22 +33,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called When we, or another client parts a channel.
  */
-public class ChannelPartEvent extends ParserEvent {
+public class ChannelPartEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
     private final String reason;
 
     public ChannelPartEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String reason) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.reason = checkNotNull(reason);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelPasswordChangedEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelPasswordChangedEvent.java
@@ -24,25 +24,15 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
-
 import java.time.LocalDateTime;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Called when a channel password changes.
  */
-public class ChannelPasswordChangedEvent extends ParserEvent {
+public class ChannelPasswordChangedEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
-
-    public ChannelPasswordChangedEvent(final Parser parser, final LocalDateTime date,
-                                  final ChannelInfo channel) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+    public ChannelPasswordChangedEvent(final Parser parser, final LocalDateTime date, final ChannelInfo channel) {
+        super(parser, date, channel);
     }
 
-    public ChannelInfo getChannel() {
-        return channel;
-    }
 }

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelQuitEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelQuitEvent.java
@@ -33,22 +33,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called When we, or another client quits IRC (Called once per channel the user was on).
  */
-public class ChannelQuitEvent extends ParserEvent {
+public class ChannelQuitEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
     private final String reason;
 
     public ChannelQuitEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String reason) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.reason = checkNotNull(reason);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelSelfJoinEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelSelfJoinEvent.java
@@ -24,25 +24,16 @@ package com.dmdirc.parser.events;
 
 import com.dmdirc.parser.interfaces.ChannelInfo;
 import com.dmdirc.parser.interfaces.Parser;
-
 import java.time.LocalDateTime;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Called when we join a channel.
  */
-public class ChannelSelfJoinEvent extends ParserEvent {
-
-    private final ChannelInfo channel;
+public class ChannelSelfJoinEvent extends ChannelEvent {
 
     public ChannelSelfJoinEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
     }
 
-    public ChannelInfo getChannel() {
-        return channel;
-    }
 }

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelSingleModeChangeEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelSingleModeChangeEvent.java
@@ -33,9 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Called when the channel modes are changed or discovered.
  */
-public class ChannelSingleModeChangeEvent extends ParserEvent {
+public class ChannelSingleModeChangeEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo client;
     private final String host;
     private final String modes;
@@ -43,15 +42,10 @@ public class ChannelSingleModeChangeEvent extends ParserEvent {
     public ChannelSingleModeChangeEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo client, final String host,
             final String modes) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.client = checkNotNull(client);
         this.host = checkNotNull(host);
         this.modes = checkNotNull(modes);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getClient() {

--- a/common/src/main/java/com/dmdirc/parser/events/ChannelUserModeChangeEvent.java
+++ b/common/src/main/java/com/dmdirc/parser/events/ChannelUserModeChangeEvent.java
@@ -33,9 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  *  Called when a users channel mode is changed.
  */
-public class ChannelUserModeChangeEvent extends ParserEvent {
+public class ChannelUserModeChangeEvent extends ChannelEvent {
 
-    private final ChannelInfo channel;
     private final ChannelClientInfo targetClient;
     private final ChannelClientInfo client;
     private final String host;
@@ -44,16 +43,11 @@ public class ChannelUserModeChangeEvent extends ParserEvent {
     public ChannelUserModeChangeEvent(final Parser parser, final LocalDateTime date,
             final ChannelInfo channel, final ChannelClientInfo targetClient,
             final ChannelClientInfo client, final String host, final String mode) {
-        super(parser, date);
-        this.channel = checkNotNull(channel);
+        super(parser, date, channel);
         this.targetClient = checkNotNull(targetClient);
         this.client = checkNotNull(client);
         this.host = checkNotNull(host);
         this.mode = checkNotNull(mode);
-    }
-
-    public ChannelInfo getChannel() {
-        return channel;
     }
 
     public ChannelClientInfo getTargetClient() {


### PR DESCRIPTION
This allows clients to listen for ChannelEvents and filter on
channel names, rather than having to handle every single
individual event type.