### PR TITLE
Fix call debug info

### DIFF
--- a/irc/src/main/java/com/dmdirc/parser/irc/IRCParser.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/IRCParser.java
@@ -754,7 +754,7 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
         }
 
         resetState();
-        callDebugInfo(DEBUG_SOCKET, "Connecting to " + getURI().getHost() + ':' + getURI().getPort());
+        callDebugInfo(DEBUG_SOCKET, "Connecting to %s:%s", getURI().getHost(), getURI().getPort());
 
         currentSocketState = SocketState.OPENING;
 
@@ -823,7 +823,7 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
      * @param isUserError Is this a user error?
      */
     private void handleConnectException(final Exception e, final boolean isUserError) {
-        callDebugInfo(DEBUG_SOCKET, "Error Connecting (" + e.getMessage() + "), Aborted");
+        callDebugInfo(DEBUG_SOCKET, "Error Connecting (%s), Aborted", e.getMessage());
         final ParserError ei = new ParserError(
                 ParserError.ERROR_ERROR + (isUserError ? ParserError.ERROR_USER : 0),
                 "Exception with server socket", getLastLine());
@@ -877,7 +877,7 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
                     processLine(lastLine);
                 }
             } catch (IOException e) {
-                callDebugInfo(DEBUG_SOCKET, "Exception in main loop (" + e.getMessage() + "), Aborted");
+                callDebugInfo(DEBUG_SOCKET, "Exception in main loop (%s), Aborted", e.getMessage());
 
                 if (currentSocketState != SocketState.CLOSED) {
                     currentSocketState = SocketState.CLOSED;
@@ -1084,7 +1084,7 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
                 final Queue<Character> listModeQueue = channel.getListModeQueue();
                 for (int i = 0; i < newLine[2].length(); ++i) {
                     final Character mode = newLine[2].charAt(i);
-                    callDebugInfo(DEBUG_LMQ, "Intercepted mode request for " + channel + " for mode " + mode);
+                    callDebugInfo(DEBUG_LMQ, "Intercepted mode request for %s for mode %s", channel, mode);
                     if (chanModesOther.containsKey(mode) && chanModesOther.get(mode) == MODE_LIST) {
                         if (foundModes.contains(mode)) {
                             callDebugInfo(DEBUG_LMQ, "Already added to LMQ");
@@ -1650,7 +1650,7 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
         // MAXLIST=bdeI:50
         // MAXLIST=b:60,e:60,I:60
         // MAXBANS=30
-        callDebugInfo(DEBUG_INFO, "Looking for maxlistmodes for: " + mode);
+        callDebugInfo(DEBUG_INFO, "Looking for maxlistmodes for: %s", mode);
         // Try in MAXLIST
         int result = -2;
         if (h005Info.get(IrcConstants.ISUPPORT_MAXIMUM_LIST_MODES) != null) {
@@ -1658,15 +1658,13 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
                 result = 0;
             }
             final String maxlist = h005Info.get(IrcConstants.ISUPPORT_MAXIMUM_LIST_MODES);
-            callDebugInfo(DEBUG_INFO, "Found maxlist (" + maxlist + ')');
+            callDebugInfo(DEBUG_INFO, "Found maxlist (%s)", maxlist);
             final String[] bits = maxlist.split(",");
             for (String bit : bits) {
                 final String[] parts = bit.split(":", 2);
-                callDebugInfo(DEBUG_INFO, "Bit: " + bit + " | parts.length = " + parts.length + " ("
-                        + parts[0] + " -> " + parts[0].indexOf(mode) + ')');
+                callDebugInfo(DEBUG_INFO, "Bit: %s | parts.length = %s (%s -> %s)", bit, parts.length, parts[0], parts[0].indexOf(mode));
                 if (parts.length == 2 && parts[0].indexOf(mode) > -1) {
-                    callDebugInfo(DEBUG_INFO, "parts[0] = '" + parts[0] + "' | parts[1] = '"
-                            + parts[1] + '\'');
+                    callDebugInfo(DEBUG_INFO, "parts[0] = '%s' | parts[1] = '%s'", parts[0], parts[1]);
                     try {
                         result = Integer.parseInt(parts[1]);
                         break;
@@ -1694,7 +1692,7 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
             callDebugInfo(DEBUG_INFO, "Failed");
             callErrorInfo(new ParserError(ParserError.ERROR_ERROR + ParserError.ERROR_USER, "Unable to discover max list modes.", getLastLine()));
         }
-        callDebugInfo(DEBUG_INFO, "Result: " + result);
+        callDebugInfo(DEBUG_INFO, "Result: %s", result);
         return result;
     }
 

--- a/irc/src/main/java/com/dmdirc/parser/irc/IRCParser.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/IRCParser.java
@@ -585,7 +585,7 @@ public class IRCParser extends BaseSocketAwareParser implements SecureParser, En
      * @param args Formatting String Options
      */
     public void callDebugInfo(final int level, final String data, final Object... args) {
-        callDebugInfo(level, String.format(data, args));
+        callDebugInfo(level, args == null || args.length == 0 ? data : String.format(data, args));
     }
 
     /**

--- a/irc/src/main/java/com/dmdirc/parser/irc/processors/ProcessJoin.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/processors/ProcessJoin.java
@@ -182,11 +182,11 @@ public class ProcessJoin extends IRCProcessor {
 
             final PendingJoin pendingJoin = pendingJoins.poll();
             if (pendingJoin != null && parser.getStringConverter().equalsIgnoreCase(pendingJoin.getChannel(), channelName)) {
-                callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Guessing channel Key: " + pendingJoin.getChannel() + " -> " + pendingJoin.getKey());
+                callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Guessing channel Key: %s -> %s", pendingJoin.getChannel(), pendingJoin.getKey());
                 iChannel.setInternalPassword(pendingJoin.getKey());
             } else {
                 // Out of sync, clear
-                callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: pending join keys out of sync (Got: " + (pendingJoin == null ? pendingJoin : pendingJoin.getChannel()) + ", Wanted: " + channelName + ") - Clearing.");
+                callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: pending join keys out of sync (Got: %s, Wanted: %s) - Clearing.", (pendingJoin == null ? pendingJoin : pendingJoin.getChannel()), channelName);
                 pendingJoins.clear();
             }
 
@@ -195,10 +195,10 @@ public class ProcessJoin extends IRCProcessor {
             // Some kind of failed to join, pop the pending join queues.
             final PendingJoin pendingJoin = pendingJoins.poll();
             if (pendingJoin != null && parser.getStringConverter().equalsIgnoreCase(pendingJoin.getChannel(), sParam)) {
-                callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Failed to join channel (" + sParam + ") - Skipping " + pendingJoin.getChannel() + " (" + pendingJoin.getKey() + ")");
+                callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Failed to join channel (%s) - Skipping %s (%s)", sParam, pendingJoin.getChannel(), pendingJoin.getKey());
             } else {
                 // Out of sync, clear
-                callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Failed to join channel (" + sParam + ") - pending join keys out of sync (Got: " + (pendingJoin == null ? pendingJoin : pendingJoin.getChannel()) + ", Wanted: " + sParam + ") - Clearing.");
+                callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Failed to join channel (%s) - pending join keys out of sync (Got: %s, Wanted: %s) - Clearing.", sParam, (pendingJoin == null ? pendingJoin : pendingJoin.getChannel()), sParam);
                 pendingJoins.clear();
             }
         }
@@ -226,12 +226,12 @@ public class ProcessJoin extends IRCProcessor {
             for (final String chan : newLine[1].split(",")) {
                 final String key = keys.poll();
                 if (chan.equals("0")) {
-                    callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Ignoring possible channel Key for part-all channel: " + chan + " -> " + key);
+                    callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Ignoring possible channel Key for part-all channel: %s -> %s", chan, key);
                 } else if (getChannel(chan) == null) {
-                    callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Intercepted possible channel Key: " + chan + " -> " + key);
+                    callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Intercepted possible channel Key: %s -> %s", chan, key);
                     pendingJoins.add(new PendingJoin(chan, key));
                 } else {
-                    callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Ignoring possible channel Key for existing channel: " + chan + " -> " + key);
+                    callDebugInfo(IRCParser.DEBUG_INFO, "processJoin: Ignoring possible channel Key for existing channel: %s -> %s", chan, key);
                 }
             }
         }

--- a/irc/src/main/java/com/dmdirc/parser/irc/processors/ProcessListModes.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/processors/ProcessListModes.java
@@ -142,20 +142,20 @@ public class ProcessListModes extends IRCProcessor {
 
         // Unknown mode.
         if (mode == ' ') {
-            parser.callDebugInfo(IRCParser.DEBUG_LMQ, "Unknown mode line: " + Arrays.toString(token));
+            parser.callDebugInfo(IRCParser.DEBUG_LMQ, "Unknown mode line: %s", Arrays.toString(token));
             return;
         }
 
         final Queue<Character> listModeQueue = channel.getListModeQueue();
         if (!isCleverMode && listModeQueue != null) {
             if ("482".equals(sParam)) {
-                parser.callDebugInfo(IRCParser.DEBUG_LMQ, "Dropped LMQ mode " + listModeQueue.poll());
+                parser.callDebugInfo(IRCParser.DEBUG_LMQ, "Dropped LMQ mode %s", listModeQueue.poll());
                 return;
             } else {
                 if (listModeQueue.peek() != null) {
                     final Character oldMode = mode;
                     mode = listModeQueue.peek();
-                    parser.callDebugInfo(IRCParser.DEBUG_LMQ, "LMQ says this is " + mode);
+                    parser.callDebugInfo(IRCParser.DEBUG_LMQ, "LMQ says this is %s", mode);
 
                     boolean error = true;
 
@@ -187,7 +187,7 @@ public class ProcessListModes extends IRCProcessor {
                     // freenode-specific hacks above think the mode should be
                     // something else, error.
                     if (oldMode != mode && error) {
-                        parser.callDebugInfo(IRCParser.DEBUG_LMQ, "LMQ disagrees with guess. LMQ: " + mode + " Guess: " + oldMode);
+                        parser.callDebugInfo(IRCParser.DEBUG_LMQ, "LMQ disagrees with guess. LMQ: %s Guess: %s", mode, oldMode);
                     }
 
                     if (!isItem) {
@@ -215,7 +215,7 @@ public class ProcessListModes extends IRCProcessor {
             } // End Hyperian stupidness of using the same numeric for 3 different things..
 
             if (!channel.getAddState(mode)) {
-                callDebugInfo(IRCParser.DEBUG_INFO, "New List Mode Batch (" + mode + "): Clearing!");
+                callDebugInfo(IRCParser.DEBUG_INFO, "New List Mode Batch (%s): Clearing!", mode);
                 final Collection<ChannelListModeItem> list = channel.getListMode(mode);
                 if (list == null) {
                     parser.callErrorInfo(new ParserError(ParserError.ERROR_WARNING, "Got list mode: '" + mode + "' - but channel object doesn't agree.", parser.getLastLine()));
@@ -226,7 +226,7 @@ public class ProcessListModes extends IRCProcessor {
                         final Character otherMode = mode == 'b' ? 'q' : 'b';
 
                         if (!channel.getAddState(otherMode)) {
-                            callDebugInfo(IRCParser.DEBUG_INFO, "New List Mode Batch (" + mode + "): Clearing!");
+                            callDebugInfo(IRCParser.DEBUG_INFO, "New List Mode Batch (%s): Clearing!", mode);
                             final Collection<ChannelListModeItem> otherList = channel.getListMode(otherMode);
                             if (otherList == null) {
                                 parser.callErrorInfo(new ParserError(ParserError.ERROR_WARNING, "Got list mode: '" + otherMode + "' - but channel object doesn't agree.", parser.getLastLine()));

--- a/irc/src/main/java/com/dmdirc/parser/irc/processors/ProcessMessage.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/processors/ProcessMessage.java
@@ -262,7 +262,7 @@ public class ProcessMessage extends IRCProcessor {
                 }
             }
         } else {
-            callDebugInfo(IRCParser.DEBUG_INFO, "Message for Other (" + token[2] + ')');
+            callDebugInfo(IRCParser.DEBUG_INFO, "Message for Other (%s)", token[2]);
             if ("PRIVMSG".equalsIgnoreCase(sParam)) {
                 if (isAction) {
                     callUnknownAction(date, sMessage, token[2], firstToken);

--- a/irc/src/main/java/com/dmdirc/parser/irc/processors/ProcessMode.java
+++ b/irc/src/main/java/com/dmdirc/parser/irc/processors/ProcessMode.java
@@ -183,24 +183,20 @@ public class ProcessMode extends IRCProcessor {
                         return;
                     }
                     sModeParam = sModestr[nParam++];
-                    callDebugInfo(IRCParser.DEBUG_INFO, "User Mode: %c / %s {Positive: %b}",
-                            cMode, sModeParam, bPositive);
+                    callDebugInfo(IRCParser.DEBUG_INFO, "User Mode: %c / %s {Positive: %b}", cMode, sModeParam, bPositive);
                     final IRCChannelClientInfo iChannelClientInfo = iChannel.getChannelClient(sModeParam);
                     if (iChannelClientInfo == null) {
                         // Client not known?
-                        callDebugInfo(IRCParser.DEBUG_INFO, "User Mode for client not on channel." +
-                                " Ignoring (%s)", sModeParam);
+                        callDebugInfo(IRCParser.DEBUG_INFO, "User Mode for client not on channel. Ignoring (%s)", sModeParam);
                         continue;
                     }
-                    callDebugInfo(IRCParser.DEBUG_INFO, "\tOld Mode Value: %s",
-                            iChannelClientInfo.getAllModes());
+                    callDebugInfo(IRCParser.DEBUG_INFO, "\tOld Mode Value: %s", iChannelClientInfo.getAllModes());
                     if (bPositive) {
                         iChannelClientInfo.addMode(cMode);
                     } else {
                         iChannelClientInfo.removeMode(cMode);
                     }
-                    callChannelUserModeChanged(date, iChannel, iChannelClientInfo, setterCCI, token[0],
-                            (bPositive ? "+" : "-") + cMode);
+                    callChannelUserModeChanged(date, iChannel, iChannelClientInfo, setterCCI, token[0], (bPositive ? "+" : "-") + cMode);
                     continue;
                 } else {
                     // unknown mode - add as boolean


### PR DESCRIPTION
This commit fixes callDebugInfo in the IRCParser to not try to string.format if there are no arguments to format with.

Also converts a whole bunch of calls to callDebugInfo to pass arguments rather than using string concatenation.